### PR TITLE
refactor: separate JSON transformers for JS and TS

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -2,7 +2,7 @@ import { Parser } from "acorn";
 import fs from "fs/promises";
 import path from "path";
 import YAML from "yaml";
-import { jsonStringify } from "./utils/json.js";
+import { jsonStringifyAcorn } from "./utils/json.js";
 
 async function* walk(dir) {
   for await (const d of await fs.opendir(dir)) {
@@ -54,7 +54,7 @@ for await (const p of walk("./test262/test")) {
       // It defaults to `true` for modules, `false` for scripts, which is what we want.
     });
 
-    const json = jsonStringify(ast);
+    const json = jsonStringifyAcorn(ast);
 
     await fs.writeFile(writeFile, json);
   } catch (err) {

--- a/typescript-eslint.js
+++ b/typescript-eslint.js
@@ -1,7 +1,7 @@
 import * as parser from "@typescript-eslint/parser";
 import fs from "node:fs";
 import path from "node:path";
-import { jsonStringify } from "./utils/json.js";
+import { jsonStringifyTs } from "./utils/json.js";
 import { makeUnitsFromTest } from "./utils/typescript-make-units-from-test.cjs";
 
 async function main() {
@@ -39,7 +39,7 @@ async function main() {
           },
         });
         const { comments, tokens, ...program } = result.ast;
-        const astJson = jsonStringify(program);
+        const astJson = jsonStringifyTs(program);
         output += `__ESTREE_TEST__:PASS:` + "\n```json\n" + astJson + "\n```\n";
       } catch (e) {
         output += `__ESTREE_TEST__:FAIL:` + "\n```json\n" + e.message + "\n```\n";


### PR DESCRIPTION
Pure refactor. Introduce separate "transformers" for Acorn and TS-ESLint AST to JSON conversion. This will come in useful later when we want to alter field order for TS-ESLint AST, but not Acorn AST.