### PR TITLE
chore(deps): bump `@typescript-eslint/parser` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "start": "node ./index.js"
   },
   "devDependencies": {
-    "@typescript-eslint/parser": "^8.26.1",
+    "@typescript-eslint/parser": "^8.32.0",
     "acorn": "8.14.1",
     "estree-walker": "^3.0.3",
     "yaml": "^2.7.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     devDependencies:
       '@typescript-eslint/parser':
-        specifier: ^8.26.1
-        version: 8.31.1(eslint@9.26.0)(typescript@5.8.3)
+        specifier: ^8.32.0
+        version: 8.32.0(eslint@9.26.0)(typescript@5.8.3)
       acorn:
         specifier: 8.14.1
         version: 8.14.1
@@ -103,29 +103,29 @@ packages:
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
-  '@typescript-eslint/parser@8.31.1':
-    resolution: {integrity: sha512-oU/OtYVydhXnumd0BobL9rkJg7wFJ9bFFPmSmB/bf/XWN85hlViji59ko6bSKBXyseT9V8l+CN1nwmlbiN0G7Q==}
+  '@typescript-eslint/parser@8.32.0':
+    resolution: {integrity: sha512-B2MdzyWxCE2+SqiZHAjPphft+/2x2FlO9YBx7eKE1BCb+rqBlQdhtAEhzIEdozHd55DXPmxBdpMygFJjfjjA9A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <5.9.0'
 
-  '@typescript-eslint/scope-manager@8.31.1':
-    resolution: {integrity: sha512-BMNLOElPxrtNQMIsFHE+3P0Yf1z0dJqV9zLdDxN/xLlWMlXK/ApEsVEKzpizg9oal8bAT5Sc7+ocal7AC1HCVw==}
+  '@typescript-eslint/scope-manager@8.32.0':
+    resolution: {integrity: sha512-jc/4IxGNedXkmG4mx4nJTILb6TMjL66D41vyeaPWvDUmeYQzF3lKtN15WsAeTr65ce4mPxwopPSo1yUUAWw0hQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/types@8.31.1':
-    resolution: {integrity: sha512-SfepaEFUDQYRoA70DD9GtytljBePSj17qPxFHA/h3eg6lPTqGJ5mWOtbXCk1YrVU1cTJRd14nhaXWFu0l2troQ==}
+  '@typescript-eslint/types@8.32.0':
+    resolution: {integrity: sha512-O5Id6tGadAZEMThM6L9HmVf5hQUXNSxLVKeGJYWNhhVseps/0LddMkp7//VDkzwJ69lPL0UmZdcZwggj9akJaA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/typescript-estree@8.31.1':
-    resolution: {integrity: sha512-kaA0ueLe2v7KunYOyWYtlf/QhhZb7+qh4Yw6Ni5kgukMIG+iP773tjgBiLWIXYumWCwEq3nLW+TUywEp8uEeag==}
+  '@typescript-eslint/typescript-estree@8.32.0':
+    resolution: {integrity: sha512-pU9VD7anSCOIoBFnhTGfOzlVFQIA1XXiQpH/CezqOBaDppRwTglJzCC6fUQGpfwey4T183NKhF1/mfatYmjRqQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <5.9.0'
 
-  '@typescript-eslint/visitor-keys@8.31.1':
-    resolution: {integrity: sha512-I+/rgqOVBn6f0o7NDTmAPWWC6NuqhV174lfYvAm9fUaWeiefLdux9/YI3/nLugEn9L8fcSi0XmpKi/r5u0nmpw==}
+  '@typescript-eslint/visitor-keys@8.32.0':
+    resolution: {integrity: sha512-1rYQTCLFFzOI5Nl0c8LUpJT8HxpwVRn9E4CkMsYfuN6ctmQqExjSTzzSk0Tz2apmXy7WU6/6fyaZVVA/thPN+w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   accepts@2.0.0:
@@ -851,29 +851,29 @@ snapshots:
 
   '@types/json-schema@7.0.15': {}
 
-  '@typescript-eslint/parser@8.31.1(eslint@9.26.0)(typescript@5.8.3)':
+  '@typescript-eslint/parser@8.32.0(eslint@9.26.0)(typescript@5.8.3)':
     dependencies:
-      '@typescript-eslint/scope-manager': 8.31.1
-      '@typescript-eslint/types': 8.31.1
-      '@typescript-eslint/typescript-estree': 8.31.1(typescript@5.8.3)
-      '@typescript-eslint/visitor-keys': 8.31.1
+      '@typescript-eslint/scope-manager': 8.32.0
+      '@typescript-eslint/types': 8.32.0
+      '@typescript-eslint/typescript-estree': 8.32.0(typescript@5.8.3)
+      '@typescript-eslint/visitor-keys': 8.32.0
       debug: 4.4.0
       eslint: 9.26.0
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/scope-manager@8.31.1':
+  '@typescript-eslint/scope-manager@8.32.0':
     dependencies:
-      '@typescript-eslint/types': 8.31.1
-      '@typescript-eslint/visitor-keys': 8.31.1
+      '@typescript-eslint/types': 8.32.0
+      '@typescript-eslint/visitor-keys': 8.32.0
 
-  '@typescript-eslint/types@8.31.1': {}
+  '@typescript-eslint/types@8.32.0': {}
 
-  '@typescript-eslint/typescript-estree@8.31.1(typescript@5.8.3)':
+  '@typescript-eslint/typescript-estree@8.32.0(typescript@5.8.3)':
     dependencies:
-      '@typescript-eslint/types': 8.31.1
-      '@typescript-eslint/visitor-keys': 8.31.1
+      '@typescript-eslint/types': 8.32.0
+      '@typescript-eslint/visitor-keys': 8.32.0
       debug: 4.4.0
       fast-glob: 3.3.3
       is-glob: 4.0.3
@@ -884,9 +884,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/visitor-keys@8.31.1':
+  '@typescript-eslint/visitor-keys@8.32.0':
     dependencies:
-      '@typescript-eslint/types': 8.31.1
+      '@typescript-eslint/types': 8.32.0
       eslint-visitor-keys: 4.2.0
 
   accepts@2.0.0:

--- a/test-typescript/tests/cases/compiler/anyMappedTypesError.ts.md
+++ b/test-typescript/tests/cases/compiler/anyMappedTypesError.ts.md
@@ -45,7 +45,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": null
       },

--- a/test-typescript/tests/cases/compiler/awaitedTypeStrictNull.ts.md
+++ b/test-typescript/tests/cases/compiler/awaitedTypeStrictNull.ts.md
@@ -3064,7 +3064,7 @@ __ESTREE_TEST__:PASS:
                     "typeAnnotation": null
                   },
                   "nameType": null,
-                  "optional": null,
+                  "optional": false,
                   "readonly": null,
                   "typeAnnotation": {
                     "type": "TSTypeReference",

--- a/test-typescript/tests/cases/compiler/callOfConditionalTypeWithConcreteBranches.ts.md
+++ b/test-typescript/tests/cases/compiler/callOfConditionalTypeWithConcreteBranches.ts.md
@@ -589,7 +589,7 @@ __ESTREE_TEST__:PASS:
               "typeAnnotation": null
             },
             "nameType": null,
-            "optional": null,
+            "optional": false,
             "readonly": null,
             "typeAnnotation": {
               "type": "TSIndexedAccessType",
@@ -1484,7 +1484,7 @@ __ESTREE_TEST__:PASS:
             "typeAnnotation": null
           },
           "nameType": null,
-          "optional": null,
+          "optional": false,
           "readonly": null,
           "typeAnnotation": {
             "type": "TSConditionalType",

--- a/test-typescript/tests/cases/compiler/circularBaseTypes.ts.md
+++ b/test-typescript/tests/cases/compiler/circularBaseTypes.ts.md
@@ -355,7 +355,7 @@ __ESTREE_TEST__:PASS:
               "typeAnnotation": null
             },
             "nameType": null,
-            "optional": null,
+            "optional": false,
             "readonly": null,
             "typeAnnotation": {
               "type": "TSStringKeyword",

--- a/test-typescript/tests/cases/compiler/circularConstrainedMappedTypeNoCrash.ts.md
+++ b/test-typescript/tests/cases/compiler/circularConstrainedMappedTypeNoCrash.ts.md
@@ -54,7 +54,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSConditionalType",

--- a/test-typescript/tests/cases/compiler/circularContextualMappedType.ts.md
+++ b/test-typescript/tests/cases/compiler/circularContextualMappedType.ts.md
@@ -122,7 +122,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSTypeReference",

--- a/test-typescript/tests/cases/compiler/circularInlineMappedGenericTupleTypeNoCrash.ts.md
+++ b/test-typescript/tests/cases/compiler/circularInlineMappedGenericTupleTypeNoCrash.ts.md
@@ -76,7 +76,7 @@ __ESTREE_TEST__:PASS:
                   "typeAnnotation": null
                 },
                 "nameType": null,
-                "optional": null,
+                "optional": false,
                 "readonly": null,
                 "typeAnnotation": {
                   "type": "TSTypeLiteral",
@@ -281,7 +281,7 @@ __ESTREE_TEST__:PASS:
                         "typeAnnotation": null
                       },
                       "nameType": null,
-                      "optional": null,
+                      "optional": false,
                       "readonly": null,
                       "typeAnnotation": {
                         "type": "TSTypeLiteral",

--- a/test-typescript/tests/cases/compiler/circularMappedTypeConstraint.ts.md
+++ b/test-typescript/tests/cases/compiler/circularMappedTypeConstraint.ts.md
@@ -165,7 +165,7 @@ __ESTREE_TEST__:PASS:
                   "typeAnnotation": null
                 }
               },
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSTypeReference",

--- a/test-typescript/tests/cases/compiler/circularReferenceInReturnType2.ts.md
+++ b/test-typescript/tests/cases/compiler/circularReferenceInReturnType2.ts.md
@@ -614,7 +614,7 @@ __ESTREE_TEST__:PASS:
                               "typeAnnotation": null
                             },
                             "nameType": null,
-                            "optional": null,
+                            "optional": false,
                             "readonly": null,
                             "typeAnnotation": {
                               "type": "TSTypeReference",

--- a/test-typescript/tests/cases/compiler/circularlyConstrainedMappedTypeContainingConditionalNoInfiniteInstantiationDepth.ts.md
+++ b/test-typescript/tests/cases/compiler/circularlyConstrainedMappedTypeContainingConditionalNoInfiniteInstantiationDepth.ts.md
@@ -2435,7 +2435,7 @@ __ESTREE_TEST__:PASS:
             "typeAnnotation": null
           },
           "nameType": null,
-          "optional": null,
+          "optional": false,
           "readonly": null,
           "typeAnnotation": {
             "type": "TSConditionalType",

--- a/test-typescript/tests/cases/compiler/circularlySimplifyingConditionalTypesNoCrash.ts.md
+++ b/test-typescript/tests/cases/compiler/circularlySimplifyingConditionalTypesNoCrash.ts.md
@@ -269,7 +269,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSConditionalType",

--- a/test-typescript/tests/cases/compiler/classReferencedInContextualParameterWithinItsOwnBaseExpression.ts.md
+++ b/test-typescript/tests/cases/compiler/classReferencedInContextualParameterWithinItsOwnBaseExpression.ts.md
@@ -678,7 +678,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSConditionalType",

--- a/test-typescript/tests/cases/compiler/coAndContraVariantInferences3.ts.md
+++ b/test-typescript/tests/cases/compiler/coAndContraVariantInferences3.ts.md
@@ -346,7 +346,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": true,
         "typeAnnotation": {
           "type": "TSFunctionType",
@@ -781,7 +781,7 @@ __ESTREE_TEST__:PASS:
                   "typeAnnotation": null
                 },
                 "nameType": null,
-                "optional": null,
+                "optional": false,
                 "readonly": null,
                 "typeAnnotation": {
                   "type": "TSIndexedAccessType",
@@ -1054,7 +1054,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSFunctionType",

--- a/test-typescript/tests/cases/compiler/complexRecursiveCollections.ts.md
+++ b/test-typescript/tests/cases/compiler/complexRecursiveCollections.ts.md
@@ -29549,7 +29549,7 @@ __ESTREE_TEST__:PASS:
                                   "typeAnnotation": null
                                 },
                                 "nameType": null,
-                                "optional": null,
+                                "optional": false,
                                 "readonly": null,
                                 "typeAnnotation": {
                                   "type": "TSAnyKeyword",

--- a/test-typescript/tests/cases/compiler/complicatedIndexedAccessKeyofReliesOnKeyofNeverUpperBound.ts.md
+++ b/test-typescript/tests/cases/compiler/complicatedIndexedAccessKeyofReliesOnKeyofNeverUpperBound.ts.md
@@ -517,7 +517,7 @@ __ESTREE_TEST__:PASS:
                       "typeAnnotation": null
                     },
                     "nameType": null,
-                    "optional": null,
+                    "optional": false,
                     "readonly": null,
                     "typeAnnotation": {
                       "type": "TSTypeReference",
@@ -564,7 +564,7 @@ __ESTREE_TEST__:PASS:
                       "typeAnnotation": null
                     },
                     "nameType": null,
-                    "optional": null,
+                    "optional": false,
                     "readonly": null,
                     "typeAnnotation": {
                       "type": "TSNeverKeyword",

--- a/test-typescript/tests/cases/compiler/computedTypesKeyofNoIndexSignatureType.ts.md
+++ b/test-typescript/tests/cases/compiler/computedTypesKeyofNoIndexSignatureType.ts.md
@@ -59,7 +59,7 @@ __ESTREE_TEST__:PASS:
               "typeAnnotation": null
             },
             "nameType": null,
-            "optional": null,
+            "optional": false,
             "readonly": null,
             "typeAnnotation": {
               "type": "TSTypeReference",
@@ -698,7 +698,7 @@ __ESTREE_TEST__:PASS:
             "typeAnnotation": null
           }
         },
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSIndexedAccessType",

--- a/test-typescript/tests/cases/compiler/conditionalTypeAssignabilityWhenDeferred.ts.md
+++ b/test-typescript/tests/cases/compiler/conditionalTypeAssignabilityWhenDeferred.ts.md
@@ -84,7 +84,7 @@ __ESTREE_TEST__:PASS:
               "typeAnnotation": null
             },
             "nameType": null,
-            "optional": null,
+            "optional": false,
             "readonly": null,
             "typeAnnotation": {
               "type": "TSConditionalType",

--- a/test-typescript/tests/cases/compiler/conditionalTypeContextualTypeSimplificationsSuceeds.ts.md
+++ b/test-typescript/tests/cases/compiler/conditionalTypeContextualTypeSimplificationsSuceeds.ts.md
@@ -189,7 +189,7 @@ __ESTREE_TEST__:PASS:
                   "typeAnnotation": null
                 },
                 "nameType": null,
-                "optional": null,
+                "optional": false,
                 "readonly": null,
                 "typeAnnotation": {
                   "type": "TSIndexedAccessType",
@@ -262,7 +262,7 @@ __ESTREE_TEST__:PASS:
                   "typeAnnotation": null
                 },
                 "nameType": null,
-                "optional": null,
+                "optional": false,
                 "readonly": null,
                 "typeAnnotation": {
                   "type": "TSIndexedAccessType",
@@ -446,7 +446,7 @@ __ESTREE_TEST__:PASS:
                   "typeAnnotation": null
                 },
                 "nameType": null,
-                "optional": null,
+                "optional": false,
                 "readonly": null,
                 "typeAnnotation": {
                   "type": "TSIndexedAccessType",
@@ -615,7 +615,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSIndexedAccessType",

--- a/test-typescript/tests/cases/compiler/consistentAliasVsNonAliasRecordBehavior.ts.md
+++ b/test-typescript/tests/cases/compiler/consistentAliasVsNonAliasRecordBehavior.ts.md
@@ -48,7 +48,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSTypeReference",

--- a/test-typescript/tests/cases/compiler/constraintOfRecursivelyMappedTypeWithConditionalIsResolvable.ts.md
+++ b/test-typescript/tests/cases/compiler/constraintOfRecursivelyMappedTypeWithConditionalIsResolvable.ts.md
@@ -177,7 +177,7 @@ __ESTREE_TEST__:PASS:
             "typeAnnotation": null
           },
           "nameType": null,
-          "optional": null,
+          "optional": false,
           "readonly": null,
           "typeAnnotation": {
             "type": "TSConditionalType",
@@ -831,7 +831,7 @@ __ESTREE_TEST__:PASS:
             "typeAnnotation": null
           },
           "nameType": null,
-          "optional": null,
+          "optional": false,
           "readonly": null,
           "typeAnnotation": {
             "type": "TSTypeReference",

--- a/test-typescript/tests/cases/compiler/contextualComputedNonBindablePropertyType.ts.md
+++ b/test-typescript/tests/cases/compiler/contextualComputedNonBindablePropertyType.ts.md
@@ -108,7 +108,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSTypeReference",
@@ -296,7 +296,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSFunctionType",
@@ -726,7 +726,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSFunctionType",

--- a/test-typescript/tests/cases/compiler/contextualPropertyOfGenericFilteringMappedType.ts.md
+++ b/test-typescript/tests/cases/compiler/contextualPropertyOfGenericFilteringMappedType.ts.md
@@ -112,7 +112,7 @@ __ESTREE_TEST__:PASS:
                   "typeAnnotation": null
                 }
               },
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSFunctionType",
@@ -612,7 +612,7 @@ __ESTREE_TEST__:PASS:
                   }
                 }
               },
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSFunctionType",

--- a/test-typescript/tests/cases/compiler/contextualPropertyOfGenericMappedType.ts.md
+++ b/test-typescript/tests/cases/compiler/contextualPropertyOfGenericMappedType.ts.md
@@ -98,7 +98,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSFunctionType",

--- a/test-typescript/tests/cases/compiler/contextualTypeBasedOnIntersectionWithAnyInTheMix3.ts.md
+++ b/test-typescript/tests/cases/compiler/contextualTypeBasedOnIntersectionWithAnyInTheMix3.ts.md
@@ -280,7 +280,7 @@ __ESTREE_TEST__:PASS:
                     "typeAnnotation": null
                   },
                   "nameType": null,
-                  "optional": null,
+                  "optional": false,
                   "readonly": null,
                   "typeAnnotation": {
                     "type": "TSArrayType",

--- a/test-typescript/tests/cases/compiler/contextualTypeBasedOnIntersectionWithAnyInTheMix5.ts.md
+++ b/test-typescript/tests/cases/compiler/contextualTypeBasedOnIntersectionWithAnyInTheMix5.ts.md
@@ -219,7 +219,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSConditionalType",

--- a/test-typescript/tests/cases/compiler/contextualTypeFunctionObjectPropertyIntersection.ts.md
+++ b/test-typescript/tests/cases/compiler/contextualTypeFunctionObjectPropertyIntersection.ts.md
@@ -2837,7 +2837,7 @@ __ESTREE_TEST__:PASS:
                     "typeAnnotation": null
                   },
                   "nameType": null,
-                  "optional": null,
+                  "optional": false,
                   "readonly": null,
                   "typeAnnotation": {
                     "type": "TSObjectKeyword",
@@ -3035,7 +3035,7 @@ __ESTREE_TEST__:PASS:
               "typeAnnotation": null
             },
             "nameType": null,
-            "optional": null,
+            "optional": false,
             "readonly": null,
             "typeAnnotation": {
               "type": "TSObjectKeyword",
@@ -3601,7 +3601,7 @@ __ESTREE_TEST__:PASS:
               "typeAnnotation": null
             },
             "nameType": null,
-            "optional": null,
+            "optional": false,
             "readonly": null,
             "typeAnnotation": {
               "type": "TSConditionalType",

--- a/test-typescript/tests/cases/compiler/contextualTypeSelfReferencing.ts.md
+++ b/test-typescript/tests/cases/compiler/contextualTypeSelfReferencing.ts.md
@@ -124,7 +124,7 @@ __ESTREE_TEST__:PASS:
               "typeAnnotation": null
             },
             "nameType": null,
-            "optional": null,
+            "optional": false,
             "readonly": null,
             "typeAnnotation": {
               "type": "TSTypeReference",

--- a/test-typescript/tests/cases/compiler/contextualTypesNegatedTypeLikeConstraintInGenericMappedType2.ts.md
+++ b/test-typescript/tests/cases/compiler/contextualTypesNegatedTypeLikeConstraintInGenericMappedType2.ts.md
@@ -332,7 +332,7 @@ __ESTREE_TEST__:PASS:
                                   "typeAnnotation": null
                                 },
                                 "nameType": null,
-                                "optional": null,
+                                "optional": false,
                                 "readonly": true,
                                 "typeAnnotation": {
                                   "type": "TSFunctionType",
@@ -552,7 +552,7 @@ __ESTREE_TEST__:PASS:
                                   "typeAnnotation": null
                                 },
                                 "nameType": null,
-                                "optional": null,
+                                "optional": false,
                                 "readonly": true,
                                 "typeAnnotation": {
                                   "type": "TSNeverKeyword",

--- a/test-typescript/tests/cases/compiler/contextualTypesNegatedTypeLikeConstraintInGenericMappedType3.ts.md
+++ b/test-typescript/tests/cases/compiler/contextualTypesNegatedTypeLikeConstraintInGenericMappedType3.ts.md
@@ -104,7 +104,7 @@ __ESTREE_TEST__:PASS:
             "typeAnnotation": null
           }
         },
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSIndexedAccessType",

--- a/test-typescript/tests/cases/compiler/contextuallyTypedSymbolNamedProperties.ts.md
+++ b/test-typescript/tests/cases/compiler/contextuallyTypedSymbolNamedProperties.ts.md
@@ -424,7 +424,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSFunctionType",

--- a/test-typescript/tests/cases/compiler/contravariantOnlyInferenceFromAnnotatedFunction.ts.md
+++ b/test-typescript/tests/cases/compiler/contravariantOnlyInferenceFromAnnotatedFunction.ts.md
@@ -54,7 +54,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSTypeLiteral",

--- a/test-typescript/tests/cases/compiler/correlatedUnions.ts.md
+++ b/test-typescript/tests/cases/compiler/correlatedUnions.ts.md
@@ -177,7 +177,7 @@ __ESTREE_TEST__:PASS:
             "typeAnnotation": null
           },
           "nameType": null,
-          "optional": null,
+          "optional": false,
           "readonly": null,
           "typeAnnotation": {
             "type": "TSTypeLiteral",
@@ -1541,7 +1541,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSTypeReference",
@@ -2198,7 +2198,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSFunctionType",
@@ -2529,7 +2529,7 @@ __ESTREE_TEST__:PASS:
             "typeAnnotation": null
           },
           "nameType": null,
-          "optional": null,
+          "optional": false,
           "readonly": null,
           "typeAnnotation": {
             "type": "TSTypeLiteral",
@@ -3516,7 +3516,7 @@ __ESTREE_TEST__:PASS:
             "typeAnnotation": null
           },
           "nameType": null,
-          "optional": null,
+          "optional": false,
           "readonly": null,
           "typeAnnotation": {
             "type": "TSTypeLiteral",
@@ -4546,7 +4546,7 @@ __ESTREE_TEST__:PASS:
             "typeAnnotation": null
           },
           "nameType": null,
-          "optional": null,
+          "optional": false,
           "readonly": null,
           "typeAnnotation": {
             "type": "TSTypeLiteral",
@@ -6391,7 +6391,7 @@ __ESTREE_TEST__:PASS:
                         "typeAnnotation": null
                       },
                       "nameType": null,
-                      "optional": null,
+                      "optional": false,
                       "readonly": null,
                       "typeAnnotation": {
                         "type": "TSFunctionType",
@@ -7303,7 +7303,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSTypeReference",
@@ -9603,7 +9603,7 @@ __ESTREE_TEST__:PASS:
               }
             }
           },
-          "optional": null,
+          "optional": false,
           "readonly": null,
           "typeAnnotation": {
             "type": "TSTypeReference",
@@ -9978,7 +9978,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSIndexedAccessType",
@@ -10419,7 +10419,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSMappedType",
@@ -10476,7 +10476,7 @@ __ESTREE_TEST__:PASS:
             "typeAnnotation": null
           },
           "nameType": null,
-          "optional": null,
+          "optional": false,
           "readonly": null,
           "typeAnnotation": {
             "type": "TSNumberKeyword",

--- a/test-typescript/tests/cases/compiler/declarationAssertionNodeNotReusedWhenTypeNotEquivalent1.ts.md
+++ b/test-typescript/tests/cases/compiler/declarationAssertionNodeNotReusedWhenTypeNotEquivalent1.ts.md
@@ -670,7 +670,7 @@ __ESTREE_TEST__:PASS:
               "typeAnnotation": null
             },
             "nameType": null,
-            "optional": null,
+            "optional": false,
             "readonly": null,
             "typeAnnotation": {
               "type": "TSTypeReference",

--- a/test-typescript/tests/cases/compiler/declarationEmitArrowFunctionNoRenaming.ts.md
+++ b/test-typescript/tests/cases/compiler/declarationEmitArrowFunctionNoRenaming.ts.md
@@ -73,7 +73,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSTypeReference",

--- a/test-typescript/tests/cases/compiler/declarationEmitExactOptionalPropertyTypesNodeNotReused.ts.md
+++ b/test-typescript/tests/cases/compiler/declarationEmitExactOptionalPropertyTypesNodeNotReused.ts.md
@@ -352,7 +352,7 @@ __ESTREE_TEST__:PASS:
                 "end": 203
               }
             },
-            "optional": null,
+            "optional": false,
             "readonly": null,
             "typeAnnotation": {
               "type": "TSIndexedAccessType",

--- a/test-typescript/tests/cases/compiler/declarationEmitInlinedDistributiveConditional.ts.md
+++ b/test-typescript/tests/cases/compiler/declarationEmitInlinedDistributiveConditional.ts.md
@@ -724,7 +724,7 @@ __ESTREE_TEST__:PASS:
               "typeAnnotation": null
             },
             "nameType": null,
-            "optional": null,
+            "optional": false,
             "readonly": null,
             "typeAnnotation": {
               "type": "TSIndexedAccessType",
@@ -907,7 +907,7 @@ __ESTREE_TEST__:PASS:
               "typeAnnotation": null
             },
             "nameType": null,
-            "optional": null,
+            "optional": false,
             "readonly": null,
             "typeAnnotation": {
               "type": "TSIndexedAccessType",

--- a/test-typescript/tests/cases/compiler/declarationEmitMappedPrivateTypeTypeParameter.ts.md
+++ b/test-typescript/tests/cases/compiler/declarationEmitMappedPrivateTypeTypeParameter.ts.md
@@ -183,7 +183,7 @@ __ESTREE_TEST__:PASS:
             "typeAnnotation": null
           },
           "nameType": null,
-          "optional": null,
+          "optional": false,
           "readonly": null,
           "typeAnnotation": {
             "type": "TSAnyKeyword",

--- a/test-typescript/tests/cases/compiler/declarationEmitMappedTypeDistributivityPreservesConstraints.ts.md
+++ b/test-typescript/tests/cases/compiler/declarationEmitMappedTypeDistributivityPreservesConstraints.ts.md
@@ -146,7 +146,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSIndexedAccessType",
@@ -274,7 +274,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSTypeReference",

--- a/test-typescript/tests/cases/compiler/declarationEmitMappedTypePropertyFromNumericStringKey.ts.md
+++ b/test-typescript/tests/cases/compiler/declarationEmitMappedTypePropertyFromNumericStringKey.ts.md
@@ -130,7 +130,7 @@ __ESTREE_TEST__:PASS:
                           "typeAnnotation": null
                         },
                         "nameType": null,
-                        "optional": null,
+                        "optional": false,
                         "readonly": null,
                         "typeAnnotation": {
                           "type": "TSUnionType",

--- a/test-typescript/tests/cases/compiler/declarationEmitMappedTypeTemplateTypeofSymbol.ts.md
+++ b/test-typescript/tests/cases/compiler/declarationEmitMappedTypeTemplateTypeofSymbol.ts.md
@@ -109,7 +109,7 @@ __ESTREE_TEST__:PASS:
                     "typeAnnotation": null
                   },
                   "nameType": null,
-                  "optional": null,
+                  "optional": false,
                   "readonly": null,
                   "typeAnnotation": {
                     "type": "TSLiteralType",

--- a/test-typescript/tests/cases/compiler/declarationEmitNestedAnonymousMappedType.ts.md
+++ b/test-typescript/tests/cases/compiler/declarationEmitNestedAnonymousMappedType.ts.md
@@ -153,7 +153,7 @@ __ESTREE_TEST__:PASS:
                     }
                   }
                 },
-                "optional": null,
+                "optional": false,
                 "readonly": null,
                 "typeAnnotation": {
                   "type": "TSIndexedAccessType",
@@ -242,7 +242,7 @@ __ESTREE_TEST__:PASS:
                   "typeAnnotation": null
                 },
                 "nameType": null,
-                "optional": null,
+                "optional": false,
                 "readonly": null,
                 "typeAnnotation": {
                   "type": "TSIndexedAccessType",

--- a/test-typescript/tests/cases/compiler/declarationEmitObjectAssignedDefaultExport.ts.md
+++ b/test-typescript/tests/cases/compiler/declarationEmitObjectAssignedDefaultExport.ts.md
@@ -156,7 +156,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSIndexedAccessType",

--- a/test-typescript/tests/cases/compiler/declarationEmitOptionalMappedTypePropertyNoStrictNullChecks1.ts.md
+++ b/test-typescript/tests/cases/compiler/declarationEmitOptionalMappedTypePropertyNoStrictNullChecks1.ts.md
@@ -59,7 +59,7 @@ __ESTREE_TEST__:PASS:
               "typeAnnotation": null
             },
             "nameType": null,
-            "optional": null,
+            "optional": false,
             "readonly": null,
             "typeAnnotation": {
               "type": "TSIndexedAccessType",
@@ -331,7 +331,7 @@ __ESTREE_TEST__:PASS:
                 }
               ]
             },
-            "optional": null,
+            "optional": false,
             "readonly": null,
             "typeAnnotation": {
               "type": "TSFunctionType",

--- a/test-typescript/tests/cases/compiler/declarationEmitOptionalMappedTypePropertyNoStrictNullChecks2.ts.md
+++ b/test-typescript/tests/cases/compiler/declarationEmitOptionalMappedTypePropertyNoStrictNullChecks2.ts.md
@@ -59,7 +59,7 @@ __ESTREE_TEST__:PASS:
               "typeAnnotation": null
             },
             "nameType": null,
-            "optional": null,
+            "optional": false,
             "readonly": null,
             "typeAnnotation": {
               "type": "TSIndexedAccessType",
@@ -331,7 +331,7 @@ __ESTREE_TEST__:PASS:
                 }
               ]
             },
-            "optional": null,
+            "optional": false,
             "readonly": null,
             "typeAnnotation": {
               "type": "TSFunctionType",

--- a/test-typescript/tests/cases/compiler/declarationEmitOptionalMappedTypePropertyNoStrictNullChecks3.ts.md
+++ b/test-typescript/tests/cases/compiler/declarationEmitOptionalMappedTypePropertyNoStrictNullChecks3.ts.md
@@ -59,7 +59,7 @@ __ESTREE_TEST__:PASS:
               "typeAnnotation": null
             },
             "nameType": null,
-            "optional": null,
+            "optional": false,
             "readonly": null,
             "typeAnnotation": {
               "type": "TSIndexedAccessType",
@@ -331,7 +331,7 @@ __ESTREE_TEST__:PASS:
                 }
               ]
             },
-            "optional": null,
+            "optional": false,
             "readonly": null,
             "typeAnnotation": {
               "type": "TSFunctionType",

--- a/test-typescript/tests/cases/compiler/declarationEmitQualifiedAliasTypeArgument.ts.md
+++ b/test-typescript/tests/cases/compiler/declarationEmitQualifiedAliasTypeArgument.ts.md
@@ -270,7 +270,7 @@ __ESTREE_TEST__:PASS:
             "typeAnnotation": null
           },
           "nameType": null,
-          "optional": null,
+          "optional": false,
           "readonly": null,
           "typeAnnotation": {
             "type": "TSStringKeyword",

--- a/test-typescript/tests/cases/compiler/declarationEmitRecursiveConditionalAliasPreserved.ts.md
+++ b/test-typescript/tests/cases/compiler/declarationEmitRecursiveConditionalAliasPreserved.ts.md
@@ -1067,7 +1067,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSTypeReference",
@@ -1231,7 +1231,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSConditionalType",
@@ -2455,7 +2455,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSIndexedAccessType",
@@ -2505,7 +2505,7 @@ __ESTREE_TEST__:PASS:
                     "typeAnnotation": null
                   },
                   "nameType": null,
-                  "optional": null,
+                  "optional": false,
                   "readonly": null,
                   "typeAnnotation": {
                     "type": "TSTypeReference",

--- a/test-typescript/tests/cases/compiler/declarationEmitShadowingInferNotRenamed.ts.md
+++ b/test-typescript/tests/cases/compiler/declarationEmitShadowingInferNotRenamed.ts.md
@@ -344,7 +344,7 @@ __ESTREE_TEST__:PASS:
                       "typeAnnotation": null
                     },
                     "nameType": null,
-                    "optional": null,
+                    "optional": false,
                     "readonly": null,
                     "typeAnnotation": {
                       "type": "TSConditionalType",

--- a/test-typescript/tests/cases/compiler/declarationEmitUsingAlternativeContainingModules1.ts.md
+++ b/test-typescript/tests/cases/compiler/declarationEmitUsingAlternativeContainingModules1.ts.md
@@ -1985,7 +1985,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSIndexedAccessType",
@@ -4160,7 +4160,7 @@ __ESTREE_TEST__:PASS:
               "typeAnnotation": null
             },
             "nameType": null,
-            "optional": null,
+            "optional": false,
             "readonly": null,
             "typeAnnotation": {
               "type": "TSConditionalType",

--- a/test-typescript/tests/cases/compiler/declarationEmitUsingAlternativeContainingModules2.ts.md
+++ b/test-typescript/tests/cases/compiler/declarationEmitUsingAlternativeContainingModules2.ts.md
@@ -1985,7 +1985,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSIndexedAccessType",
@@ -4160,7 +4160,7 @@ __ESTREE_TEST__:PASS:
               "typeAnnotation": null
             },
             "nameType": null,
-            "optional": null,
+            "optional": false,
             "readonly": null,
             "typeAnnotation": {
               "type": "TSConditionalType",

--- a/test-typescript/tests/cases/compiler/declarationQuotedMembers.ts.md
+++ b/test-typescript/tests/cases/compiler/declarationQuotedMembers.ts.md
@@ -57,7 +57,7 @@ __ESTREE_TEST__:PASS:
                     "typeAnnotation": null
                   },
                   "nameType": null,
-                  "optional": null,
+                  "optional": false,
                   "readonly": null,
                   "typeAnnotation": {
                     "type": "TSNumberKeyword",

--- a/test-typescript/tests/cases/compiler/deeplyNestedConstraints.ts.md
+++ b/test-typescript/tests/cases/compiler/deeplyNestedConstraints.ts.md
@@ -133,7 +133,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSUnionType",

--- a/test-typescript/tests/cases/compiler/deeplyNestedMappedTypes.ts.md
+++ b/test-typescript/tests/cases/compiler/deeplyNestedMappedTypes.ts.md
@@ -54,7 +54,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSTypeReference",
@@ -741,7 +741,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSTypeReference",
@@ -2560,7 +2560,7 @@ __ESTREE_TEST__:PASS:
             "typeAnnotation": null
           },
           "nameType": null,
-          "optional": null,
+          "optional": false,
           "readonly": null,
           "typeAnnotation": {
             "type": "TSTypeReference",
@@ -3990,7 +3990,7 @@ __ESTREE_TEST__:PASS:
               "typeAnnotation": null
             },
             "nameType": null,
-            "optional": null,
+            "optional": false,
             "readonly": null,
             "typeAnnotation": {
               "type": "TSIndexedAccessType",
@@ -5147,7 +5147,7 @@ __ESTREE_TEST__:PASS:
               "typeAnnotation": null
             },
             "nameType": null,
-            "optional": null,
+            "optional": false,
             "readonly": null,
             "typeAnnotation": {
               "type": "TSConditionalType",
@@ -5472,7 +5472,7 @@ __ESTREE_TEST__:PASS:
               "typeAnnotation": null
             },
             "nameType": null,
-            "optional": null,
+            "optional": false,
             "readonly": null,
             "typeAnnotation": {
               "type": "TSConditionalType",
@@ -5797,7 +5797,7 @@ __ESTREE_TEST__:PASS:
               "typeAnnotation": null
             },
             "nameType": null,
-            "optional": null,
+            "optional": false,
             "readonly": null,
             "typeAnnotation": {
               "type": "TSConditionalType",
@@ -6882,7 +6882,7 @@ __ESTREE_TEST__:PASS:
                   "typeAnnotation": null
                 },
                 "nameType": null,
-                "optional": null,
+                "optional": false,
                 "readonly": null,
                 "typeAnnotation": {
                   "type": "TSTypeReference",

--- a/test-typescript/tests/cases/compiler/deferredConditionalTypes.ts.md
+++ b/test-typescript/tests/cases/compiler/deferredConditionalTypes.ts.md
@@ -2589,7 +2589,7 @@ __ESTREE_TEST__:PASS:
             }
           }
         },
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSAnyKeyword",

--- a/test-typescript/tests/cases/compiler/deferredLookupTypeResolution.ts.md
+++ b/test-typescript/tests/cases/compiler/deferredLookupTypeResolution.ts.md
@@ -72,7 +72,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSLiteralType",
@@ -733,7 +733,7 @@ __ESTREE_TEST__:PASS:
             "typeAnnotation": null
           },
           "nameType": null,
-          "optional": null,
+          "optional": false,
           "readonly": null,
           "typeAnnotation": {
             "type": "TSAnyKeyword",

--- a/test-typescript/tests/cases/compiler/deferredLookupTypeResolution2.ts.md
+++ b/test-typescript/tests/cases/compiler/deferredLookupTypeResolution2.ts.md
@@ -72,7 +72,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSLiteralType",

--- a/test-typescript/tests/cases/compiler/definiteAssignmentOfDestructuredVariable.ts.md
+++ b/test-typescript/tests/cases/compiler/definiteAssignmentOfDestructuredVariable.ts.md
@@ -182,7 +182,7 @@ __ESTREE_TEST__:PASS:
                   "typeAnnotation": null
                 },
                 "nameType": null,
-                "optional": null,
+                "optional": false,
                 "readonly": null,
                 "typeAnnotation": {
                   "type": "TSIndexedAccessType",

--- a/test-typescript/tests/cases/compiler/deleteExpressionMustBeOptional.ts.md
+++ b/test-typescript/tests/cases/compiler/deleteExpressionMustBeOptional.ts.md
@@ -449,7 +449,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSNumberKeyword",

--- a/test-typescript/tests/cases/compiler/deleteExpressionMustBeOptional_exactOptionalPropertyTypes.ts.md
+++ b/test-typescript/tests/cases/compiler/deleteExpressionMustBeOptional_exactOptionalPropertyTypes.ts.md
@@ -449,7 +449,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSNumberKeyword",

--- a/test-typescript/tests/cases/compiler/destructuredMaappedTypeIsNotImplicitlyAny.ts.md
+++ b/test-typescript/tests/cases/compiler/destructuredMaappedTypeIsNotImplicitlyAny.ts.md
@@ -224,7 +224,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSNumberKeyword",

--- a/test-typescript/tests/cases/compiler/errorElaboration.ts.md
+++ b/test-typescript/tests/cases/compiler/errorElaboration.ts.md
@@ -580,7 +580,7 @@ __ESTREE_TEST__:PASS:
             "typeAnnotation": null
           },
           "nameType": null,
-          "optional": null,
+          "optional": false,
           "readonly": null,
           "typeAnnotation": {
             "type": "TSTypeReference",

--- a/test-typescript/tests/cases/compiler/excessPropertyCheckIntersectionWithRecursiveType.ts.md
+++ b/test-typescript/tests/cases/compiler/excessPropertyCheckIntersectionWithRecursiveType.ts.md
@@ -292,7 +292,7 @@ __ESTREE_TEST__:PASS:
                         "typeAnnotation": null
                       },
                       "nameType": null,
-                      "optional": null,
+                      "optional": false,
                       "readonly": null,
                       "typeAnnotation": {
                         "type": "TSTypeReference",
@@ -805,7 +805,7 @@ __ESTREE_TEST__:PASS:
                         "typeAnnotation": null
                       },
                       "nameType": null,
-                      "optional": null,
+                      "optional": false,
                       "readonly": null,
                       "typeAnnotation": {
                         "type": "TSTypeReference",
@@ -1397,7 +1397,7 @@ __ESTREE_TEST__:PASS:
                         "typeAnnotation": null
                       },
                       "nameType": null,
-                      "optional": null,
+                      "optional": false,
                       "readonly": null,
                       "typeAnnotation": {
                         "type": "TSTypeReference",
@@ -1910,7 +1910,7 @@ __ESTREE_TEST__:PASS:
                         "typeAnnotation": null
                       },
                       "nameType": null,
-                      "optional": null,
+                      "optional": false,
                       "readonly": null,
                       "typeAnnotation": {
                         "type": "TSTypeReference",

--- a/test-typescript/tests/cases/compiler/excessPropertyChecksWithNestedIntersections.ts.md
+++ b/test-typescript/tests/cases/compiler/excessPropertyChecksWithNestedIntersections.ts.md
@@ -1656,7 +1656,7 @@ __ESTREE_TEST__:PASS:
             "typeAnnotation": null
           },
           "nameType": null,
-          "optional": null,
+          "optional": false,
           "readonly": null,
           "typeAnnotation": {
             "type": "TSConditionalType",

--- a/test-typescript/tests/cases/compiler/genericConditionalConstrainedToUnknownNotAssignableToConcreteObject.ts.md
+++ b/test-typescript/tests/cases/compiler/genericConditionalConstrainedToUnknownNotAssignableToConcreteObject.ts.md
@@ -187,7 +187,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSFunctionType",

--- a/test-typescript/tests/cases/compiler/genericFunctionInference2.ts.md
+++ b/test-typescript/tests/cases/compiler/genericFunctionInference2.ts.md
@@ -167,7 +167,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSTypeReference",
@@ -1050,7 +1050,7 @@ __ESTREE_TEST__:PASS:
               "typeAnnotation": null
             },
             "nameType": null,
-            "optional": null,
+            "optional": false,
             "readonly": null,
             "typeAnnotation": {
               "type": "TSFunctionType",

--- a/test-typescript/tests/cases/compiler/genericFunctionsAndConditionalInference.ts.md
+++ b/test-typescript/tests/cases/compiler/genericFunctionsAndConditionalInference.ts.md
@@ -54,7 +54,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSTypeLiteral",
@@ -1711,7 +1711,7 @@ __ESTREE_TEST__:PASS:
                           "typeAnnotation": null
                         },
                         "nameType": null,
-                        "optional": null,
+                        "optional": false,
                         "readonly": null,
                         "typeAnnotation": {
                           "type": "TSTypeReference",

--- a/test-typescript/tests/cases/compiler/genericIndexedAccessMethodIntersectionCanBeAccessed.ts.md
+++ b/test-typescript/tests/cases/compiler/genericIndexedAccessMethodIntersectionCanBeAccessed.ts.md
@@ -54,7 +54,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSIntersectionType",
@@ -240,7 +240,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSIntersectionType",

--- a/test-typescript/tests/cases/compiler/genericMappedTypeAsClause.ts.md
+++ b/test-typescript/tests/cases/compiler/genericMappedTypeAsClause.ts.md
@@ -203,7 +203,7 @@ __ESTREE_TEST__:PASS:
             }
           ]
         },
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSIndexedAccessType",
@@ -1091,7 +1091,7 @@ __ESTREE_TEST__:PASS:
             "typeAnnotation": null
           }
         },
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSTypeReference",

--- a/test-typescript/tests/cases/compiler/genericTupleWithSimplifiableElements.ts.md
+++ b/test-typescript/tests/cases/compiler/genericTupleWithSimplifiableElements.ts.md
@@ -135,7 +135,7 @@ __ESTREE_TEST__:PASS:
                             "typeAnnotation": null
                           },
                           "nameType": null,
-                          "optional": null,
+                          "optional": false,
                           "readonly": null,
                           "typeAnnotation": {
                             "type": "TSTupleType",
@@ -376,7 +376,7 @@ __ESTREE_TEST__:PASS:
                             "typeAnnotation": null
                           },
                           "nameType": null,
-                          "optional": null,
+                          "optional": false,
                           "readonly": null,
                           "typeAnnotation": {
                             "type": "TSTupleType",
@@ -571,7 +571,7 @@ __ESTREE_TEST__:PASS:
                                           "typeAnnotation": null
                                         },
                                         "nameType": null,
-                                        "optional": null,
+                                        "optional": false,
                                         "readonly": null,
                                         "typeAnnotation": {
                                           "type": "TSTupleType",
@@ -746,7 +746,7 @@ __ESTREE_TEST__:PASS:
                                           "typeAnnotation": null
                                         },
                                         "nameType": null,
-                                        "optional": null,
+                                        "optional": false,
                                         "readonly": null,
                                         "typeAnnotation": {
                                           "type": "TSTupleType",

--- a/test-typescript/tests/cases/compiler/higherOrderMappedIndexLookupInference.ts.md
+++ b/test-typescript/tests/cases/compiler/higherOrderMappedIndexLookupInference.ts.md
@@ -713,7 +713,7 @@ __ESTREE_TEST__:PASS:
                     "typeAnnotation": null
                   },
                   "nameType": null,
-                  "optional": null,
+                  "optional": false,
                   "readonly": null,
                   "typeAnnotation": {
                     "type": "TSIndexedAccessType",
@@ -836,7 +836,7 @@ __ESTREE_TEST__:PASS:
                     "typeAnnotation": null
                   },
                   "nameType": null,
-                  "optional": null,
+                  "optional": false,
                   "readonly": null,
                   "typeAnnotation": {
                     "type": "TSIndexedAccessType",
@@ -957,7 +957,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSIndexedAccessType",
@@ -1189,7 +1189,7 @@ __ESTREE_TEST__:PASS:
                       "typeAnnotation": null
                     },
                     "nameType": null,
-                    "optional": null,
+                    "optional": false,
                     "readonly": null,
                     "typeAnnotation": {
                       "type": "TSIndexedAccessType",

--- a/test-typescript/tests/cases/compiler/homomorphicMappedTypeNesting.ts.md
+++ b/test-typescript/tests/cases/compiler/homomorphicMappedTypeNesting.ts.md
@@ -210,7 +210,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSConditionalType",
@@ -394,7 +394,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSIndexedAccessType",

--- a/test-typescript/tests/cases/compiler/homomorphicMappedTypeWithNonHomomorphicInstantiationSpreadable1.ts.md
+++ b/test-typescript/tests/cases/compiler/homomorphicMappedTypeWithNonHomomorphicInstantiationSpreadable1.ts.md
@@ -54,7 +54,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSTypeLiteral",
@@ -215,7 +215,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSTypeLiteral",

--- a/test-typescript/tests/cases/compiler/hugeDeclarationOutputGetsTruncatedWithError.ts.md
+++ b/test-typescript/tests/cases/compiler/hugeDeclarationOutputGetsTruncatedWithError.ts.md
@@ -509,7 +509,7 @@ __ESTREE_TEST__:PASS:
                         "typeAnnotation": null
                       },
                       "nameType": null,
-                      "optional": null,
+                      "optional": false,
                       "readonly": null,
                       "typeAnnotation": {
                         "type": "TSMappedType",
@@ -540,7 +540,7 @@ __ESTREE_TEST__:PASS:
                           "typeAnnotation": null
                         },
                         "nameType": null,
-                        "optional": null,
+                        "optional": false,
                         "readonly": null,
                         "typeAnnotation": {
                           "type": "TSTemplateLiteralType",

--- a/test-typescript/tests/cases/compiler/importPropertyFromMappedType.ts.md
+++ b/test-typescript/tests/cases/compiler/importPropertyFromMappedType.ts.md
@@ -126,7 +126,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSUnknownKeyword",

--- a/test-typescript/tests/cases/compiler/incorrectRecursiveMappedTypeConstraint.ts.md
+++ b/test-typescript/tests/cases/compiler/incorrectRecursiveMappedTypeConstraint.ts.md
@@ -191,7 +191,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSNumberKeyword",

--- a/test-typescript/tests/cases/compiler/indexedAccessNormalization.ts.md
+++ b/test-typescript/tests/cases/compiler/indexedAccessNormalization.ts.md
@@ -54,7 +54,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSTypeLiteral",

--- a/test-typescript/tests/cases/compiler/indexedAccessRetainsIndexSignature.ts.md
+++ b/test-typescript/tests/cases/compiler/indexedAccessRetainsIndexSignature.ts.md
@@ -72,7 +72,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSTypeReference",
@@ -119,7 +119,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSNeverKeyword",
@@ -672,7 +672,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSIndexedAccessType",

--- a/test-typescript/tests/cases/compiler/indexingTypesWithNever.ts.md
+++ b/test-typescript/tests/cases/compiler/indexingTypesWithNever.ts.md
@@ -873,7 +873,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSIndexedAccessType",
@@ -1701,7 +1701,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSIndexedAccessType",

--- a/test-typescript/tests/cases/compiler/inferConditionalConstraintMappedMember.ts.md
+++ b/test-typescript/tests/cases/compiler/inferConditionalConstraintMappedMember.ts.md
@@ -58,7 +58,7 @@ __ESTREE_TEST__:PASS:
             "typeAnnotation": null
           },
           "nameType": null,
-          "optional": null,
+          "optional": false,
           "readonly": null,
           "typeAnnotation": {
             "type": "TSConditionalType",
@@ -141,7 +141,7 @@ __ESTREE_TEST__:PASS:
             "typeAnnotation": null
           },
           "nameType": null,
-          "optional": null,
+          "optional": false,
           "readonly": null,
           "typeAnnotation": {
             "type": "TSInferType",

--- a/test-typescript/tests/cases/compiler/inferRestArgumentsMappedTuple.ts.md
+++ b/test-typescript/tests/cases/compiler/inferRestArgumentsMappedTuple.ts.md
@@ -145,7 +145,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSConditionalType",
@@ -676,7 +676,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSTypeReference",

--- a/test-typescript/tests/cases/compiler/inferTypeConstraintInstantiationCircularity.ts.md
+++ b/test-typescript/tests/cases/compiler/inferTypeConstraintInstantiationCircularity.ts.md
@@ -54,7 +54,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSNumberKeyword",
@@ -370,7 +370,7 @@ __ESTREE_TEST__:PASS:
                           "typeAnnotation": null
                         },
                         "nameType": null,
-                        "optional": null,
+                        "optional": false,
                         "readonly": null,
                         "typeAnnotation": {
                           "type": "TSNumberKeyword",
@@ -853,7 +853,7 @@ __ESTREE_TEST__:PASS:
                             "typeAnnotation": null
                           },
                           "nameType": null,
-                          "optional": null,
+                          "optional": false,
                           "readonly": null,
                           "typeAnnotation": {
                             "type": "TSNumberKeyword",
@@ -984,7 +984,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSIndexedAccessType",
@@ -1123,7 +1123,7 @@ __ESTREE_TEST__:PASS:
             "typeAnnotation": null
           },
           "nameType": null,
-          "optional": null,
+          "optional": false,
           "readonly": null,
           "typeAnnotation": {
             "type": "TSConditionalType",
@@ -1508,7 +1508,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSIndexedAccessType",
@@ -2047,7 +2047,7 @@ __ESTREE_TEST__:PASS:
                           "typeAnnotation": null
                         },
                         "nameType": null,
-                        "optional": null,
+                        "optional": false,
                         "readonly": null,
                         "typeAnnotation": {
                           "type": "TSIndexedAccessType",

--- a/test-typescript/tests/cases/compiler/inferenceAndSelfReferentialConstraint.ts.md
+++ b/test-typescript/tests/cases/compiler/inferenceAndSelfReferentialConstraint.ts.md
@@ -67,7 +67,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSConditionalType",

--- a/test-typescript/tests/cases/compiler/inferenceExactOptionalProperties2.ts.md
+++ b/test-typescript/tests/cases/compiler/inferenceExactOptionalProperties2.ts.md
@@ -1047,7 +1047,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSTypeLiteral",
@@ -1326,7 +1326,7 @@ __ESTREE_TEST__:PASS:
                         "typeAnnotation": null
                       },
                       "nameType": null,
-                      "optional": null,
+                      "optional": false,
                       "readonly": null,
                       "typeAnnotation": {
                         "type": "TSIndexedAccessType",

--- a/test-typescript/tests/cases/compiler/inferenceShouldFailOnEvolvingArrays.ts.md
+++ b/test-typescript/tests/cases/compiler/inferenceShouldFailOnEvolvingArrays.ts.md
@@ -168,7 +168,7 @@ __ESTREE_TEST__:PASS:
                   "typeAnnotation": null
                 },
                 "nameType": null,
-                "optional": null,
+                "optional": false,
                 "readonly": null,
                 "typeAnnotation": {
                   "type": "TSTypeReference",
@@ -543,7 +543,7 @@ __ESTREE_TEST__:PASS:
                   "typeAnnotation": null
                 },
                 "nameType": null,
-                "optional": null,
+                "optional": false,
                 "readonly": null,
                 "typeAnnotation": {
                   "type": "TSTypeReference",

--- a/test-typescript/tests/cases/compiler/inferenceUnionOfObjectsMappedContextualType.ts.md
+++ b/test-typescript/tests/cases/compiler/inferenceUnionOfObjectsMappedContextualType.ts.md
@@ -214,7 +214,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSTypeLiteral",

--- a/test-typescript/tests/cases/compiler/infiniteConstraints.ts.md
+++ b/test-typescript/tests/cases/compiler/infiniteConstraints.ts.md
@@ -79,7 +79,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSIndexedAccessType",
@@ -323,7 +323,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSIndexedAccessType",
@@ -640,7 +640,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSConditionalType",
@@ -1185,7 +1185,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSConditionalType",
@@ -2007,7 +2007,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSTypeReference",

--- a/test-typescript/tests/cases/compiler/inlineMappedTypeModifierDeclarationEmit.ts.md
+++ b/test-typescript/tests/cases/compiler/inlineMappedTypeModifierDeclarationEmit.ts.md
@@ -953,7 +953,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSIndexedAccessType",

--- a/test-typescript/tests/cases/compiler/instantiationExpressionErrorNoCrash.ts.md
+++ b/test-typescript/tests/cases/compiler/instantiationExpressionErrorNoCrash.ts.md
@@ -421,7 +421,7 @@ __ESTREE_TEST__:PASS:
                     "typeAnnotation": null
                   },
                   "nameType": null,
-                  "optional": null,
+                  "optional": false,
                   "readonly": null,
                   "typeAnnotation": {
                     "type": "TSTypeReference",

--- a/test-typescript/tests/cases/compiler/intersectionConstraintReduction.ts.md
+++ b/test-typescript/tests/cases/compiler/intersectionConstraintReduction.ts.md
@@ -1096,7 +1096,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSTypeReference",
@@ -1463,7 +1463,7 @@ __ESTREE_TEST__:PASS:
                   "typeAnnotation": null
                 },
                 "nameType": null,
-                "optional": null,
+                "optional": false,
                 "readonly": null,
                 "typeAnnotation": {
                   "type": "TSTypeReference",

--- a/test-typescript/tests/cases/compiler/intersectionType_useDefineForClassFields.ts.md
+++ b/test-typescript/tests/cases/compiler/intersectionType_useDefineForClassFields.ts.md
@@ -66,7 +66,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSAnyKeyword",

--- a/test-typescript/tests/cases/compiler/invariantGenericErrorElaboration.ts.md
+++ b/test-typescript/tests/cases/compiler/invariantGenericErrorElaboration.ts.md
@@ -479,7 +479,7 @@ __ESTREE_TEST__:PASS:
                   "typeAnnotation": null
                 },
                 "nameType": null,
-                "optional": null,
+                "optional": false,
                 "readonly": null,
                 "typeAnnotation": {
                   "type": "TSIndexedAccessType",
@@ -576,7 +576,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSTypeReference",

--- a/test-typescript/tests/cases/compiler/jsDeclarationsWithDefaultAsNamespaceLikeMerge.ts.md
+++ b/test-typescript/tests/cases/compiler/jsDeclarationsWithDefaultAsNamespaceLikeMerge.ts.md
@@ -119,7 +119,7 @@ __ESTREE_TEST__:PASS:
                   "typeAnnotation": null
                 },
                 "nameType": null,
-                "optional": null,
+                "optional": false,
                 "readonly": null,
                 "typeAnnotation": {
                   "type": "TSTypeReference",
@@ -242,7 +242,7 @@ __ESTREE_TEST__:PASS:
                   "typeAnnotation": null
                 },
                 "nameType": null,
-                "optional": null,
+                "optional": false,
                 "readonly": null,
                 "typeAnnotation": {
                   "type": "TSTypeReference",

--- a/test-typescript/tests/cases/compiler/jsFileImportPreservedWhenUsed.ts.md
+++ b/test-typescript/tests/cases/compiler/jsFileImportPreservedWhenUsed.ts.md
@@ -370,7 +370,7 @@ __ESTREE_TEST__:PASS:
                   "typeAnnotation": null
                 },
                 "nameType": null,
-                "optional": null,
+                "optional": false,
                 "readonly": null,
                 "typeAnnotation": {
                   "type": "TSTypeReference",

--- a/test-typescript/tests/cases/compiler/jsxElementTypeLiteralWithGeneric.tsx.md
+++ b/test-typescript/tests/cases/compiler/jsxElementTypeLiteralWithGeneric.tsx.md
@@ -160,7 +160,7 @@ __ESTREE_TEST__:PASS:
                             "typeAnnotation": null
                           },
                           "nameType": null,
-                          "optional": null,
+                          "optional": false,
                           "readonly": null,
                           "typeAnnotation": {
                             "type": "TSConditionalType",

--- a/test-typescript/tests/cases/compiler/jsxInferenceProducesLiteralAsExpected.tsx.md
+++ b/test-typescript/tests/cases/compiler/jsxInferenceProducesLiteralAsExpected.tsx.md
@@ -106,7 +106,7 @@ __ESTREE_TEST__:PASS:
             "typeAnnotation": null
           },
           "nameType": null,
-          "optional": null,
+          "optional": false,
           "readonly": null,
           "typeAnnotation": {
             "type": "TSConditionalType",

--- a/test-typescript/tests/cases/compiler/jsxNamespaceImplicitImportJSXNamespaceFromConfigPickedOverGlobalOne.tsx.md
+++ b/test-typescript/tests/cases/compiler/jsxNamespaceImplicitImportJSXNamespaceFromConfigPickedOverGlobalOne.tsx.md
@@ -1673,7 +1673,7 @@ __ESTREE_TEST__:PASS:
                   "typeAnnotation": null
                 },
                 "nameType": null,
-                "optional": null,
+                "optional": false,
                 "readonly": null,
                 "typeAnnotation": {
                   "type": "TSIntersectionType",

--- a/test-typescript/tests/cases/compiler/jsxNamespaceImplicitImportJSXNamespaceFromPragmaPickedOverGlobalOne.tsx.md
+++ b/test-typescript/tests/cases/compiler/jsxNamespaceImplicitImportJSXNamespaceFromPragmaPickedOverGlobalOne.tsx.md
@@ -1673,7 +1673,7 @@ __ESTREE_TEST__:PASS:
                   "typeAnnotation": null
                 },
                 "nameType": null,
-                "optional": null,
+                "optional": false,
                 "readonly": null,
                 "typeAnnotation": {
                   "type": "TSIntersectionType",

--- a/test-typescript/tests/cases/compiler/keyRemappingKeyofResult.ts.md
+++ b/test-typescript/tests/cases/compiler/keyRemappingKeyofResult.ts.md
@@ -356,7 +356,7 @@ __ESTREE_TEST__:PASS:
             "end": 234
           }
         },
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSAnyKeyword",
@@ -969,7 +969,7 @@ __ESTREE_TEST__:PASS:
                   "end": 892
                 }
               },
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSAnyKeyword",
@@ -1811,7 +1811,7 @@ __ESTREE_TEST__:PASS:
                   "typeAnnotation": null
                 }
               },
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSAnyKeyword",

--- a/test-typescript/tests/cases/compiler/localTypeParameterInferencePriority.ts.md
+++ b/test-typescript/tests/cases/compiler/localTypeParameterInferencePriority.ts.md
@@ -88,7 +88,7 @@ __ESTREE_TEST__:PASS:
               "typeAnnotation": null
             },
             "nameType": null,
-            "optional": null,
+            "optional": false,
             "readonly": null,
             "typeAnnotation": {
               "type": "TSIndexedAccessType",

--- a/test-typescript/tests/cases/compiler/mappedArrayTupleIntersections.ts.md
+++ b/test-typescript/tests/cases/compiler/mappedArrayTupleIntersections.ts.md
@@ -141,7 +141,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSTypeReference",
@@ -710,7 +710,7 @@ __ESTREE_TEST__:PASS:
                   "typeAnnotation": null
                 },
                 "nameType": null,
-                "optional": null,
+                "optional": false,
                 "readonly": null,
                 "typeAnnotation": {
                   "type": "TSLiteralType",

--- a/test-typescript/tests/cases/compiler/mappedToToIndexSignatureInference.ts.md
+++ b/test-typescript/tests/cases/compiler/mappedToToIndexSignatureInference.ts.md
@@ -71,7 +71,7 @@ __ESTREE_TEST__:PASS:
                           "typeAnnotation": null
                         },
                         "nameType": null,
-                        "optional": null,
+                        "optional": false,
                         "readonly": null,
                         "typeAnnotation": {
                           "type": "TSTypeReference",

--- a/test-typescript/tests/cases/compiler/mappedTypeAndIndexSignatureRelation.ts.md
+++ b/test-typescript/tests/cases/compiler/mappedTypeAndIndexSignatureRelation.ts.md
@@ -54,7 +54,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSIndexedAccessType",
@@ -508,7 +508,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSTypeReference",
@@ -745,7 +745,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSIndexedAccessType",
@@ -859,7 +859,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSTypeReference",
@@ -1182,7 +1182,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSIndexedAccessType",
@@ -1308,7 +1308,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSTypeReference",

--- a/test-typescript/tests/cases/compiler/mappedTypeAsStringTemplate.ts.md
+++ b/test-typescript/tests/cases/compiler/mappedTypeAsStringTemplate.ts.md
@@ -173,7 +173,7 @@ __ESTREE_TEST__:PASS:
                   }
                 ]
               },
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSNumberKeyword",

--- a/test-typescript/tests/cases/compiler/mappedTypeCircularReferenceInAccessor.ts.md
+++ b/test-typescript/tests/cases/compiler/mappedTypeCircularReferenceInAccessor.ts.md
@@ -276,7 +276,7 @@ __ESTREE_TEST__:PASS:
             "typeAnnotation": null
           },
           "nameType": null,
-          "optional": null,
+          "optional": false,
           "readonly": null,
           "typeAnnotation": {
             "type": "TSConditionalType",
@@ -556,7 +556,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSIndexedAccessType",

--- a/test-typescript/tests/cases/compiler/mappedTypeContextualTypesApplied.ts.md
+++ b/test-typescript/tests/cases/compiler/mappedTypeContextualTypesApplied.ts.md
@@ -144,7 +144,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSTypeReference",
@@ -281,7 +281,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSTypeReference",
@@ -408,7 +408,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSTypeReference",
@@ -527,7 +527,7 @@ __ESTREE_TEST__:PASS:
                     "typeAnnotation": null
                   },
                   "nameType": null,
-                  "optional": null,
+                  "optional": false,
                   "readonly": null,
                   "typeAnnotation": {
                     "type": "TSTypeReference",
@@ -666,7 +666,7 @@ __ESTREE_TEST__:PASS:
                     "typeAnnotation": null
                   },
                   "nameType": null,
-                  "optional": null,
+                  "optional": false,
                   "readonly": null,
                   "typeAnnotation": {
                     "type": "TSTypeReference",
@@ -824,7 +824,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSTypeReference",
@@ -945,7 +945,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSTypeReference",
@@ -1072,7 +1072,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSTypeReference",
@@ -1200,7 +1200,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSTypeReference",

--- a/test-typescript/tests/cases/compiler/mappedTypeGenericInstantiationPreservesHomomorphism.ts.md
+++ b/test-typescript/tests/cases/compiler/mappedTypeGenericInstantiationPreservesHomomorphism.ts.md
@@ -207,7 +207,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSIndexedAccessType",

--- a/test-typescript/tests/cases/compiler/mappedTypeGenericInstantiationPreservesInlineForm.ts.md
+++ b/test-typescript/tests/cases/compiler/mappedTypeGenericInstantiationPreservesInlineForm.ts.md
@@ -111,7 +111,7 @@ __ESTREE_TEST__:PASS:
                         "typeAnnotation": null
                       },
                       "nameType": null,
-                      "optional": null,
+                      "optional": false,
                       "readonly": null,
                       "typeAnnotation": {
                         "type": "TSIndexedAccessType",
@@ -315,7 +315,7 @@ __ESTREE_TEST__:PASS:
                   "typeAnnotation": null
                 },
                 "nameType": null,
-                "optional": null,
+                "optional": false,
                 "readonly": null,
                 "typeAnnotation": {
                   "type": "TSIndexedAccessType",

--- a/test-typescript/tests/cases/compiler/mappedTypeIndexedAccess.ts.md
+++ b/test-typescript/tests/cases/compiler/mappedTypeIndexedAccess.ts.md
@@ -54,7 +54,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSTypeLiteral",

--- a/test-typescript/tests/cases/compiler/mappedTypeIndexedAccessConstraint.ts.md
+++ b/test-typescript/tests/cases/compiler/mappedTypeIndexedAccessConstraint.ts.md
@@ -54,7 +54,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSIndexedAccessType",
@@ -284,7 +284,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSIndexedAccessType",
@@ -394,7 +394,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSIndexedAccessType",
@@ -525,7 +525,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSIndexedAccessType",
@@ -1204,7 +1204,7 @@ __ESTREE_TEST__:PASS:
                   "typeAnnotation": null
                 },
                 "nameType": null,
-                "optional": null,
+                "optional": false,
                 "readonly": null,
                 "typeAnnotation": {
                   "type": "TSIndexedAccessType",
@@ -2062,7 +2062,7 @@ __ESTREE_TEST__:PASS:
                   "typeAnnotation": null
                 },
                 "nameType": null,
-                "optional": null,
+                "optional": false,
                 "readonly": null,
                 "typeAnnotation": {
                   "type": "TSFunctionType",
@@ -3309,7 +3309,7 @@ __ESTREE_TEST__:PASS:
                   "typeAnnotation": null
                 },
                 "nameType": null,
-                "optional": null,
+                "optional": false,
                 "readonly": null,
                 "typeAnnotation": {
                   "type": "TSNumberKeyword",

--- a/test-typescript/tests/cases/compiler/mappedTypeInferenceAliasSubstitution.ts.md
+++ b/test-typescript/tests/cases/compiler/mappedTypeInferenceAliasSubstitution.ts.md
@@ -131,7 +131,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSTypeReference",
@@ -283,7 +283,7 @@ __ESTREE_TEST__:PASS:
                       "typeAnnotation": null
                     },
                     "nameType": null,
-                    "optional": null,
+                    "optional": false,
                     "readonly": null,
                     "typeAnnotation": {
                       "type": "TSTypeReference",

--- a/test-typescript/tests/cases/compiler/mappedTypeInferenceCircularity.ts.md
+++ b/test-typescript/tests/cases/compiler/mappedTypeInferenceCircularity.ts.md
@@ -45,7 +45,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSTypeReference",

--- a/test-typescript/tests/cases/compiler/mappedTypeInferenceFromApparentType.ts.md
+++ b/test-typescript/tests/cases/compiler/mappedTypeInferenceFromApparentType.ts.md
@@ -131,7 +131,7 @@ __ESTREE_TEST__:PASS:
                   "typeAnnotation": null
                 },
                 "nameType": null,
-                "optional": null,
+                "optional": false,
                 "readonly": null,
                 "typeAnnotation": {
                   "type": "TSIndexedAccessType",
@@ -276,7 +276,7 @@ __ESTREE_TEST__:PASS:
                   "typeAnnotation": null
                 },
                 "nameType": null,
-                "optional": null,
+                "optional": false,
                 "readonly": null,
                 "typeAnnotation": {
                   "type": "TSIndexedAccessType",

--- a/test-typescript/tests/cases/compiler/mappedTypeInferenceToMappedType.ts.md
+++ b/test-typescript/tests/cases/compiler/mappedTypeInferenceToMappedType.ts.md
@@ -136,7 +136,7 @@ __ESTREE_TEST__:PASS:
                         "typeAnnotation": null
                       },
                       "nameType": null,
-                      "optional": null,
+                      "optional": false,
                       "readonly": null,
                       "typeAnnotation": {
                         "type": "TSIndexedAccessType",
@@ -385,7 +385,7 @@ __ESTREE_TEST__:PASS:
                         "typeAnnotation": null
                       },
                       "nameType": null,
-                      "optional": null,
+                      "optional": false,
                       "readonly": null,
                       "typeAnnotation": {
                         "type": "TSIndexedAccessType",

--- a/test-typescript/tests/cases/compiler/mappedTypeMultiInference.ts.md
+++ b/test-typescript/tests/cases/compiler/mappedTypeMultiInference.ts.md
@@ -185,7 +185,7 @@ __ESTREE_TEST__:PASS:
             "typeAnnotation": null
           },
           "nameType": null,
-          "optional": null,
+          "optional": false,
           "readonly": null,
           "typeAnnotation": {
             "type": "TSTypeReference",

--- a/test-typescript/tests/cases/compiler/mappedTypeNestedGenericInstantiation.ts.md
+++ b/test-typescript/tests/cases/compiler/mappedTypeNestedGenericInstantiation.ts.md
@@ -219,7 +219,7 @@ __ESTREE_TEST__:PASS:
                         "typeAnnotation": null
                       },
                       "nameType": null,
-                      "optional": null,
+                      "optional": false,
                       "readonly": null,
                       "typeAnnotation": {
                         "type": "TSTypeReference",

--- a/test-typescript/tests/cases/compiler/mappedTypeNoTypeNoCrash.ts.md
+++ b/test-typescript/tests/cases/compiler/mappedTypeNoTypeNoCrash.ts.md
@@ -58,7 +58,7 @@ __ESTREE_TEST__:PASS:
             "typeAnnotation": null
           },
           "nameType": null,
-          "optional": null,
+          "optional": false,
           "readonly": null,
           "typeAnnotation": null
         },
@@ -91,7 +91,7 @@ __ESTREE_TEST__:PASS:
             "typeAnnotation": null
           },
           "nameType": null,
-          "optional": null,
+          "optional": false,
           "readonly": null,
           "typeAnnotation": {
             "type": "TSIndexedAccessType",

--- a/test-typescript/tests/cases/compiler/mappedTypeNotMistakenlyHomomorphic.ts.md
+++ b/test-typescript/tests/cases/compiler/mappedTypeNotMistakenlyHomomorphic.ts.md
@@ -423,7 +423,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSStringKeyword",

--- a/test-typescript/tests/cases/compiler/mappedTypeOverArrayWithBareAnyRestCanBeUsedAsRestParam1.ts.md
+++ b/test-typescript/tests/cases/compiler/mappedTypeOverArrayWithBareAnyRestCanBeUsedAsRestParam1.ts.md
@@ -54,7 +54,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSConditionalType",

--- a/test-typescript/tests/cases/compiler/mappedTypeParameterConstraint.ts.md
+++ b/test-typescript/tests/cases/compiler/mappedTypeParameterConstraint.ts.md
@@ -54,7 +54,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSIndexedAccessType",

--- a/test-typescript/tests/cases/compiler/mappedTypeRecursiveInference.ts.md
+++ b/test-typescript/tests/cases/compiler/mappedTypeRecursiveInference.ts.md
@@ -161,7 +161,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSTypeReference",

--- a/test-typescript/tests/cases/compiler/mappedTypeRecursiveInference2.ts.md
+++ b/test-typescript/tests/cases/compiler/mappedTypeRecursiveInference2.ts.md
@@ -387,7 +387,7 @@ __ESTREE_TEST__:PASS:
             "typeAnnotation": null
           },
           "nameType": null,
-          "optional": null,
+          "optional": false,
           "readonly": null,
           "typeAnnotation": {
             "type": "TSTypeReference",

--- a/test-typescript/tests/cases/compiler/mappedTypeTupleConstraintAssignability.ts.md
+++ b/test-typescript/tests/cases/compiler/mappedTypeTupleConstraintAssignability.ts.md
@@ -54,7 +54,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": "-",
         "typeAnnotation": {
           "type": "TSIndexedAccessType",
@@ -215,7 +215,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSTypeReference",
@@ -1651,7 +1651,7 @@ __ESTREE_TEST__:PASS:
                   "typeAnnotation": null
                 },
                 "nameType": null,
-                "optional": null,
+                "optional": false,
                 "readonly": null,
                 "typeAnnotation": {
                   "type": "TSTypeReference",

--- a/test-typescript/tests/cases/compiler/mappedTypeUnionConstrainTupleTreatedAsArrayLike.ts.md
+++ b/test-typescript/tests/cases/compiler/mappedTypeUnionConstrainTupleTreatedAsArrayLike.ts.md
@@ -54,7 +54,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSConditionalType",

--- a/test-typescript/tests/cases/compiler/mappedTypeUnionConstraintInferences.ts.md
+++ b/test-typescript/tests/cases/compiler/mappedTypeUnionConstraintInferences.ts.md
@@ -510,7 +510,7 @@ __ESTREE_TEST__:PASS:
                           "typeAnnotation": null
                         },
                         "nameType": null,
-                        "optional": null,
+                        "optional": false,
                         "readonly": null,
                         "typeAnnotation": {
                           "type": "TSIndexedAccessType",
@@ -855,7 +855,7 @@ __ESTREE_TEST__:PASS:
               "typeAnnotation": null
             },
             "nameType": null,
-            "optional": null,
+            "optional": false,
             "readonly": null,
             "typeAnnotation": {
               "type": "TSIndexedAccessType",

--- a/test-typescript/tests/cases/compiler/mappedTypeWithAsClauseAndLateBoundProperty.ts.md
+++ b/test-typescript/tests/cases/compiler/mappedTypeWithAsClauseAndLateBoundProperty.ts.md
@@ -142,7 +142,7 @@ __ESTREE_TEST__:PASS:
                     "typeAnnotation": null
                   }
                 },
-                "optional": null,
+                "optional": false,
                 "readonly": null,
                 "typeAnnotation": {
                   "type": "TSIndexedAccessType",

--- a/test-typescript/tests/cases/compiler/mappedTypeWithAsClauseAndLateBoundProperty2.ts.md
+++ b/test-typescript/tests/cases/compiler/mappedTypeWithAsClauseAndLateBoundProperty2.ts.md
@@ -126,7 +126,7 @@ __ESTREE_TEST__:PASS:
                       "typeAnnotation": null
                     }
                   },
-                  "optional": null,
+                  "optional": false,
                   "readonly": null,
                   "typeAnnotation": {
                     "type": "TSIndexedAccessType",

--- a/test-typescript/tests/cases/compiler/mappedTypeWithCombinedTypeMappers.ts.md
+++ b/test-typescript/tests/cases/compiler/mappedTypeWithCombinedTypeMappers.ts.md
@@ -54,7 +54,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": true,
         "typeAnnotation": {
           "type": "TSTypeLiteral",

--- a/test-typescript/tests/cases/compiler/mappedTypeWithNameClauseAppliedToArrayType.ts.md
+++ b/test-typescript/tests/cases/compiler/mappedTypeWithNameClauseAppliedToArrayType.ts.md
@@ -68,7 +68,7 @@ __ESTREE_TEST__:PASS:
             "typeAnnotation": null
           }
         },
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSIndexedAccessType",

--- a/test-typescript/tests/cases/compiler/mixinOverMappedTypeNoCrash.ts.md
+++ b/test-typescript/tests/cases/compiler/mixinOverMappedTypeNoCrash.ts.md
@@ -59,7 +59,7 @@ __ESTREE_TEST__:PASS:
             "typeAnnotation": null
           },
           "nameType": null,
-          "optional": null,
+          "optional": false,
           "readonly": null,
           "typeAnnotation": {
             "type": "TSIndexedAccessType",

--- a/test-typescript/tests/cases/compiler/narrowingByTypeofInSwitch.ts.md
+++ b/test-typescript/tests/cases/compiler/narrowingByTypeofInSwitch.ts.md
@@ -7597,7 +7597,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSStringKeyword",
@@ -10221,7 +10221,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSStringKeyword",

--- a/test-typescript/tests/cases/compiler/narrowingMutualSubtypes.ts.md
+++ b/test-typescript/tests/cases/compiler/narrowingMutualSubtypes.ts.md
@@ -1890,7 +1890,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSIndexedAccessType",

--- a/test-typescript/tests/cases/compiler/nestedHomomorphicMappedTypesWithArrayConstraint1.ts.md
+++ b/test-typescript/tests/cases/compiler/nestedHomomorphicMappedTypesWithArrayConstraint1.ts.md
@@ -54,7 +54,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSIndexedAccessType",

--- a/test-typescript/tests/cases/compiler/neverAsDiscriminantType.ts.md
+++ b/test-typescript/tests/cases/compiler/neverAsDiscriminantType.ts.md
@@ -974,7 +974,7 @@ __ESTREE_TEST__:PASS:
               "typeAnnotation": null
             },
             "nameType": null,
-            "optional": null,
+            "optional": false,
             "readonly": null,
             "typeAnnotation": {
               "type": "TSConditionalType",
@@ -1206,7 +1206,7 @@ __ESTREE_TEST__:PASS:
                     "typeAnnotation": null
                   },
                   "nameType": null,
-                  "optional": null,
+                  "optional": false,
                   "readonly": null,
                   "typeAnnotation": {
                     "type": "TSTypeReference",

--- a/test-typescript/tests/cases/compiler/nonNullMappedType.ts.md
+++ b/test-typescript/tests/cases/compiler/nonNullMappedType.ts.md
@@ -134,7 +134,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSUnionType",

--- a/test-typescript/tests/cases/compiler/nonNullableWithNullableGenericIndexedAccessArg.ts.md
+++ b/test-typescript/tests/cases/compiler/nonNullableWithNullableGenericIndexedAccessArg.ts.md
@@ -285,7 +285,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSTypeReference",

--- a/test-typescript/tests/cases/compiler/numericEnumMappedType.ts.md
+++ b/test-typescript/tests/cases/compiler/numericEnumMappedType.ts.md
@@ -929,7 +929,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSTypeReference",

--- a/test-typescript/tests/cases/compiler/objectLiteralEnumPropertyNames.ts.md
+++ b/test-typescript/tests/cases/compiler/objectLiteralEnumPropertyNames.ts.md
@@ -115,7 +115,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSStringKeyword",

--- a/test-typescript/tests/cases/compiler/objectRestBindingContextualInference.ts.md
+++ b/test-typescript/tests/cases/compiler/objectRestBindingContextualInference.ts.md
@@ -48,7 +48,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSStringKeyword",
@@ -130,7 +130,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSTypeReference",

--- a/test-typescript/tests/cases/compiler/optionalTupleElementsAndUndefined.ts.md
+++ b/test-typescript/tests/cases/compiler/optionalTupleElementsAndUndefined.ts.md
@@ -54,7 +54,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSTypeReference",

--- a/test-typescript/tests/cases/compiler/paramsOnlyHaveLiteralTypesWhenAppropriatelyContextualized.ts.md
+++ b/test-typescript/tests/cases/compiler/paramsOnlyHaveLiteralTypesWhenAppropriatelyContextualized.ts.md
@@ -54,7 +54,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSIndexedAccessType",

--- a/test-typescript/tests/cases/compiler/ramdaToolsNoInfinite.ts.md
+++ b/test-typescript/tests/cases/compiler/ramdaToolsNoInfinite.ts.md
@@ -4933,7 +4933,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSTypeReference",

--- a/test-typescript/tests/cases/compiler/ramdaToolsNoInfinite2.ts.md
+++ b/test-typescript/tests/cases/compiler/ramdaToolsNoInfinite2.ts.md
@@ -716,7 +716,7 @@ __ESTREE_TEST__:PASS:
                         "typeAnnotation": null
                       },
                       "nameType": null,
-                      "optional": null,
+                      "optional": false,
                       "readonly": null,
                       "typeAnnotation": {
                         "type": "TSIndexedAccessType",
@@ -923,7 +923,7 @@ __ESTREE_TEST__:PASS:
                     "typeAnnotation": null
                   },
                   "nameType": null,
-                  "optional": null,
+                  "optional": false,
                   "readonly": null,
                   "typeAnnotation": {
                     "type": "TSIndexedAccessType",
@@ -6290,7 +6290,7 @@ __ESTREE_TEST__:PASS:
                           "typeAnnotation": null
                         },
                         "nameType": null,
-                        "optional": null,
+                        "optional": false,
                         "readonly": null,
                         "typeAnnotation": {
                           "type": "TSTypeReference",
@@ -8870,7 +8870,7 @@ __ESTREE_TEST__:PASS:
                       "typeAnnotation": null
                     },
                     "nameType": null,
-                    "optional": null,
+                    "optional": false,
                     "readonly": null,
                     "typeAnnotation": {
                       "type": "TSTypeReference",
@@ -9022,7 +9022,7 @@ __ESTREE_TEST__:PASS:
                   "typeAnnotation": null
                 },
                 "nameType": null,
-                "optional": null,
+                "optional": false,
                 "readonly": null,
                 "typeAnnotation": {
                   "type": "TSTypeReference",
@@ -9895,7 +9895,7 @@ __ESTREE_TEST__:PASS:
                       "typeAnnotation": null
                     },
                     "nameType": null,
-                    "optional": null,
+                    "optional": false,
                     "readonly": null,
                     "typeAnnotation": {
                       "type": "TSConditionalType",
@@ -20931,7 +20931,7 @@ __ESTREE_TEST__:PASS:
                     "typeAnnotation": null
                   },
                   "nameType": null,
-                  "optional": null,
+                  "optional": false,
                   "readonly": null,
                   "typeAnnotation": {
                     "type": "TSConditionalType",
@@ -21497,7 +21497,7 @@ __ESTREE_TEST__:PASS:
                   "typeAnnotation": null
                 },
                 "nameType": null,
-                "optional": null,
+                "optional": false,
                 "readonly": null,
                 "typeAnnotation": {
                   "type": "TSUndefinedKeyword",
@@ -30883,7 +30883,7 @@ __ESTREE_TEST__:PASS:
                       "typeAnnotation": null
                     },
                     "nameType": null,
-                    "optional": null,
+                    "optional": false,
                     "readonly": null,
                     "typeAnnotation": {
                       "type": "TSTypeReference",

--- a/test-typescript/tests/cases/compiler/reactReduxLikeDeferredInferenceAllowsAssignment.ts.md
+++ b/test-typescript/tests/cases/compiler/reactReduxLikeDeferredInferenceAllowsAssignment.ts.md
@@ -2385,7 +2385,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSConditionalType",
@@ -4104,7 +4104,7 @@ __ESTREE_TEST__:PASS:
             "typeAnnotation": null
           },
           "nameType": null,
-          "optional": null,
+          "optional": false,
           "readonly": null,
           "typeAnnotation": {
             "type": "TSTypeReference",

--- a/test-typescript/tests/cases/compiler/recursiveConditionalCrash3.ts.md
+++ b/test-typescript/tests/cases/compiler/recursiveConditionalCrash3.ts.md
@@ -2040,7 +2040,7 @@ __ESTREE_TEST__:PASS:
                     "typeAnnotation": null
                   },
                   "nameType": null,
-                  "optional": null,
+                  "optional": false,
                   "readonly": null,
                   "typeAnnotation": {
                     "type": "TSConditionalType",

--- a/test-typescript/tests/cases/compiler/recursiveConditionalTypes2.ts.md
+++ b/test-typescript/tests/cases/compiler/recursiveConditionalTypes2.ts.md
@@ -1101,7 +1101,7 @@ __ESTREE_TEST__:PASS:
                   "typeAnnotation": null
                 },
                 "nameType": null,
-                "optional": null,
+                "optional": false,
                 "readonly": null,
                 "typeAnnotation": {
                   "type": "TSTypeReference",
@@ -1516,7 +1516,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSConditionalType",

--- a/test-typescript/tests/cases/compiler/recursiveTupleTypeInference.ts.md
+++ b/test-typescript/tests/cases/compiler/recursiveTupleTypeInference.ts.md
@@ -328,7 +328,7 @@ __ESTREE_TEST__:PASS:
             "typeAnnotation": null
           },
           "nameType": null,
-          "optional": null,
+          "optional": false,
           "readonly": null,
           "typeAnnotation": {
             "type": "TSTypeReference",
@@ -539,7 +539,7 @@ __ESTREE_TEST__:PASS:
                   "typeAnnotation": null
                 },
                 "nameType": null,
-                "optional": null,
+                "optional": false,
                 "readonly": null,
                 "typeAnnotation": {
                   "type": "TSTypeReference",

--- a/test-typescript/tests/cases/compiler/recursiveTypeAliasWithSpreadConditionalReturnNotCircular.ts.md
+++ b/test-typescript/tests/cases/compiler/recursiveTypeAliasWithSpreadConditionalReturnNotCircular.ts.md
@@ -908,7 +908,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSConditionalType",
@@ -1114,7 +1114,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSTypeReference",
@@ -1249,7 +1249,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSConditionalType",

--- a/test-typescript/tests/cases/compiler/recursiveTypeRelations.ts.md
+++ b/test-typescript/tests/cases/compiler/recursiveTypeRelations.ts.md
@@ -48,7 +48,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSStringKeyword",
@@ -1519,7 +1519,7 @@ __ESTREE_TEST__:PASS:
                   "typeAnnotation": null
                 },
                 "nameType": null,
-                "optional": null,
+                "optional": false,
                 "readonly": null,
                 "typeAnnotation": {
                   "type": "TSStringKeyword",

--- a/test-typescript/tests/cases/compiler/recursivelyExpandingUnionNoStackoverflow.ts.md
+++ b/test-typescript/tests/cases/compiler/recursivelyExpandingUnionNoStackoverflow.ts.md
@@ -87,7 +87,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSTypeReference",

--- a/test-typescript/tests/cases/compiler/restInvalidArgumentType.ts.md
+++ b/test-typescript/tests/cases/compiler/restInvalidArgumentType.ts.md
@@ -286,7 +286,7 @@ __ESTREE_TEST__:PASS:
                         "typeAnnotation": null
                       },
                       "nameType": null,
-                      "optional": null,
+                      "optional": false,
                       "readonly": null,
                       "typeAnnotation": {
                         "type": "TSIndexedAccessType",
@@ -379,7 +379,7 @@ __ESTREE_TEST__:PASS:
                         "typeAnnotation": null
                       },
                       "nameType": null,
-                      "optional": null,
+                      "optional": false,
                       "readonly": null,
                       "typeAnnotation": {
                         "type": "TSIndexedAccessType",

--- a/test-typescript/tests/cases/compiler/restParamUsingMappedTypeOverUnionConstraint.ts.md
+++ b/test-typescript/tests/cases/compiler/restParamUsingMappedTypeOverUnionConstraint.ts.md
@@ -54,7 +54,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSConditionalType",

--- a/test-typescript/tests/cases/compiler/restTypeRetainsMappyness.ts.md
+++ b/test-typescript/tests/cases/compiler/restTypeRetainsMappyness.ts.md
@@ -54,7 +54,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSIndexedAccessType",

--- a/test-typescript/tests/cases/compiler/reverseMappedContravariantInference.ts.md
+++ b/test-typescript/tests/cases/compiler/reverseMappedContravariantInference.ts.md
@@ -70,7 +70,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSFunctionType",

--- a/test-typescript/tests/cases/compiler/reverseMappedIntersectionInference1.ts.md
+++ b/test-typescript/tests/cases/compiler/reverseMappedIntersectionInference1.ts.md
@@ -54,7 +54,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSTypeLiteral",
@@ -289,7 +289,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSTypeLiteral",

--- a/test-typescript/tests/cases/compiler/reverseMappedIntersectionInference2.ts.md
+++ b/test-typescript/tests/cases/compiler/reverseMappedIntersectionInference2.ts.md
@@ -54,7 +54,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSTypeLiteral",
@@ -289,7 +289,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSTypeLiteral",

--- a/test-typescript/tests/cases/compiler/reverseMappedPartiallyInferableTypes.ts.md
+++ b/test-typescript/tests/cases/compiler/reverseMappedPartiallyInferableTypes.ts.md
@@ -742,7 +742,7 @@ __ESTREE_TEST__:PASS:
             "typeAnnotation": null
           },
           "nameType": null,
-          "optional": null,
+          "optional": false,
           "readonly": null,
           "typeAnnotation": {
             "type": "TSTypeReference",
@@ -1961,7 +1961,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSTypeReference",
@@ -2694,7 +2694,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSTupleType",
@@ -3091,7 +3091,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSTupleType",
@@ -3518,7 +3518,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": true,
         "typeAnnotation": {
           "type": "TSTypeOperator",

--- a/test-typescript/tests/cases/compiler/reverseMappedTupleContext.ts.md
+++ b/test-typescript/tests/cases/compiler/reverseMappedTupleContext.ts.md
@@ -70,7 +70,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSIndexedAccessType",
@@ -286,7 +286,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSIndexedAccessType",
@@ -571,7 +571,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSUnionType",
@@ -1227,7 +1227,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSIndexedAccessType",
@@ -1394,7 +1394,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSTypeLiteral",

--- a/test-typescript/tests/cases/compiler/reverseMappedTypeAssignableToIndex.ts.md
+++ b/test-typescript/tests/cases/compiler/reverseMappedTypeAssignableToIndex.ts.md
@@ -54,7 +54,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSTypeLiteral",

--- a/test-typescript/tests/cases/compiler/reverseMappedTypeContextualTypeNotCircular.ts.md
+++ b/test-typescript/tests/cases/compiler/reverseMappedTypeContextualTypeNotCircular.ts.md
@@ -186,7 +186,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSTypeReference",

--- a/test-typescript/tests/cases/compiler/reverseMappedTypeContextualTypesPerElementOfTupleConstraint.ts.md
+++ b/test-typescript/tests/cases/compiler/reverseMappedTypeContextualTypesPerElementOfTupleConstraint.ts.md
@@ -192,7 +192,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSTypeLiteral",

--- a/test-typescript/tests/cases/compiler/reverseMappedTypeDeepDeclarationEmit.ts.md
+++ b/test-typescript/tests/cases/compiler/reverseMappedTypeDeepDeclarationEmit.ts.md
@@ -296,7 +296,7 @@ __ESTREE_TEST__:PASS:
             "typeAnnotation": null
           },
           "nameType": null,
-          "optional": null,
+          "optional": false,
           "readonly": null,
           "typeAnnotation": {
             "type": "TSTypeReference",

--- a/test-typescript/tests/cases/compiler/reverseMappedTypeInferenceSameSource1.ts.md
+++ b/test-typescript/tests/cases/compiler/reverseMappedTypeInferenceSameSource1.ts.md
@@ -415,7 +415,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSTypeReference",

--- a/test-typescript/tests/cases/compiler/reverseMappedTypeIntersectionConstraint.ts.md
+++ b/test-typescript/tests/cases/compiler/reverseMappedTypeIntersectionConstraint.ts.md
@@ -374,7 +374,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSIndexedAccessType",
@@ -1094,7 +1094,7 @@ __ESTREE_TEST__:PASS:
                         "typeAnnotation": null
                       },
                       "nameType": null,
-                      "optional": null,
+                      "optional": false,
                       "readonly": null,
                       "typeAnnotation": {
                         "type": "TSIndexedAccessType",
@@ -1739,7 +1739,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSIndexedAccessType",
@@ -2171,7 +2171,7 @@ __ESTREE_TEST__:PASS:
                   "typeAnnotation": null
                 },
                 "nameType": null,
-                "optional": null,
+                "optional": false,
                 "readonly": null,
                 "typeAnnotation": {
                   "type": "TSIndexedAccessType",
@@ -2540,7 +2540,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSIndexedAccessType",
@@ -3123,7 +3123,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSIndexedAccessType",
@@ -3753,7 +3753,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSIndexedAccessType",
@@ -4185,7 +4185,7 @@ __ESTREE_TEST__:PASS:
             "typeAnnotation": null
           },
           "nameType": null,
-          "optional": null,
+          "optional": false,
           "readonly": "-",
           "typeAnnotation": {
             "type": "TSTypeReference",
@@ -4917,7 +4917,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSConditionalType",
@@ -5143,7 +5143,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSIndexedAccessType",

--- a/test-typescript/tests/cases/compiler/reverseMappedTypeLimitedConstraint.ts.md
+++ b/test-typescript/tests/cases/compiler/reverseMappedTypeLimitedConstraint.ts.md
@@ -150,7 +150,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSIndexedAccessType",
@@ -451,7 +451,7 @@ __ESTREE_TEST__:PASS:
                         "typeAnnotation": null
                       },
                       "nameType": null,
-                      "optional": null,
+                      "optional": false,
                       "readonly": null,
                       "typeAnnotation": {
                         "type": "TSIndexedAccessType",

--- a/test-typescript/tests/cases/compiler/reverseMappedTypePrimitiveConstraintProperty.ts.md
+++ b/test-typescript/tests/cases/compiler/reverseMappedTypePrimitiveConstraintProperty.ts.md
@@ -70,7 +70,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSIndexedAccessType",

--- a/test-typescript/tests/cases/compiler/reverseMappedTypeRecursiveInference.ts.md
+++ b/test-typescript/tests/cases/compiler/reverseMappedTypeRecursiveInference.ts.md
@@ -54,7 +54,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSTypeReference",
@@ -189,7 +189,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSConditionalType",

--- a/test-typescript/tests/cases/compiler/reverseMappedUnionInference.ts.md
+++ b/test-typescript/tests/cases/compiler/reverseMappedUnionInference.ts.md
@@ -1671,7 +1671,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSTypeReference",

--- a/test-typescript/tests/cases/compiler/signatureCombiningRestParameters1.ts.md
+++ b/test-typescript/tests/cases/compiler/signatureCombiningRestParameters1.ts.md
@@ -225,7 +225,7 @@ __ESTREE_TEST__:PASS:
                   "typeAnnotation": null
                 },
                 "nameType": null,
-                "optional": null,
+                "optional": false,
                 "readonly": null,
                 "typeAnnotation": {
                   "type": "TSFunctionType",

--- a/test-typescript/tests/cases/compiler/specedNoStackBlown.ts.md
+++ b/test-typescript/tests/cases/compiler/specedNoStackBlown.ts.md
@@ -1434,7 +1434,7 @@ __ESTREE_TEST__:PASS:
                   "typeAnnotation": null
                 },
                 "nameType": null,
-                "optional": null,
+                "optional": false,
                 "readonly": null,
                 "typeAnnotation": {
                   "type": "TSTypeReference",
@@ -2178,7 +2178,7 @@ __ESTREE_TEST__:PASS:
             "typeAnnotation": null
           },
           "nameType": null,
-          "optional": null,
+          "optional": false,
           "readonly": null,
           "typeAnnotation": {
             "type": "TSUnionType",

--- a/test-typescript/tests/cases/compiler/spreadInvalidArgumentType.ts.md
+++ b/test-typescript/tests/cases/compiler/spreadInvalidArgumentType.ts.md
@@ -286,7 +286,7 @@ __ESTREE_TEST__:PASS:
                         "typeAnnotation": null
                       },
                       "nameType": null,
-                      "optional": null,
+                      "optional": false,
                       "readonly": null,
                       "typeAnnotation": {
                         "type": "TSIndexedAccessType",
@@ -379,7 +379,7 @@ __ESTREE_TEST__:PASS:
                         "typeAnnotation": null
                       },
                       "nameType": null,
-                      "optional": null,
+                      "optional": false,
                       "readonly": null,
                       "typeAnnotation": {
                         "type": "TSIndexedAccessType",

--- a/test-typescript/tests/cases/compiler/spuriousCircularityOnTypeImport.ts.md
+++ b/test-typescript/tests/cases/compiler/spuriousCircularityOnTypeImport.ts.md
@@ -59,7 +59,7 @@ __ESTREE_TEST__:PASS:
             "typeAnnotation": null
           },
           "nameType": null,
-          "optional": null,
+          "optional": false,
           "readonly": null,
           "typeAnnotation": {
             "type": "TSIndexedAccessType",
@@ -269,7 +269,7 @@ __ESTREE_TEST__:PASS:
             "typeAnnotation": null
           },
           "nameType": null,
-          "optional": null,
+          "optional": false,
           "readonly": null,
           "typeAnnotation": {
             "type": "TSIndexedAccessType",
@@ -539,7 +539,7 @@ __ESTREE_TEST__:PASS:
                                 "typeAnnotation": null
                               },
                               "nameType": null,
-                              "optional": null,
+                              "optional": false,
                               "readonly": null,
                               "typeAnnotation": {
                                 "type": "TSTypeReference",
@@ -816,7 +816,7 @@ __ESTREE_TEST__:PASS:
                                 "typeAnnotation": null
                               },
                               "nameType": null,
-                              "optional": null,
+                              "optional": false,
                               "readonly": null,
                               "typeAnnotation": {
                                 "type": "TSTypeReference",

--- a/test-typescript/tests/cases/compiler/spyComparisonChecking.ts.md
+++ b/test-typescript/tests/cases/compiler/spyComparisonChecking.ts.md
@@ -315,7 +315,7 @@ __ESTREE_TEST__:PASS:
               "typeAnnotation": null
             },
             "nameType": null,
-            "optional": null,
+            "optional": false,
             "readonly": null,
             "typeAnnotation": {
               "type": "TSTypeReference",

--- a/test-typescript/tests/cases/compiler/strictNullNotNullIndexTypeNoLib.ts.md
+++ b/test-typescript/tests/cases/compiler/strictNullNotNullIndexTypeNoLib.ts.md
@@ -54,7 +54,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": true,
         "typeAnnotation": {
           "type": "TSIndexedAccessType",

--- a/test-typescript/tests/cases/compiler/styledComponentsInstantiaionLimitNotReached.ts.md
+++ b/test-typescript/tests/cases/compiler/styledComponentsInstantiaionLimitNotReached.ts.md
@@ -1529,7 +1529,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSIndexedAccessType",

--- a/test-typescript/tests/cases/compiler/substitutionTypeNoMergeOfAssignableType.ts.md
+++ b/test-typescript/tests/cases/compiler/substitutionTypeNoMergeOfAssignableType.ts.md
@@ -227,7 +227,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSIndexedAccessType",
@@ -372,7 +372,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSConditionalType",

--- a/test-typescript/tests/cases/compiler/substitutionTypesInIndexedAccessTypes.ts.md
+++ b/test-typescript/tests/cases/compiler/substitutionTypesInIndexedAccessTypes.ts.md
@@ -106,7 +106,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSConditionalType",

--- a/test-typescript/tests/cases/compiler/templateLiteralIntersection4.ts.md
+++ b/test-typescript/tests/cases/compiler/templateLiteralIntersection4.ts.md
@@ -224,7 +224,7 @@ __ESTREE_TEST__:PASS:
                       }
                     ]
                   },
-                  "optional": null,
+                  "optional": false,
                   "readonly": null,
                   "typeAnnotation": {
                     "type": "TSTypeReference",

--- a/test-typescript/tests/cases/compiler/twiceNestedKeyofIndexInference.ts.md
+++ b/test-typescript/tests/cases/compiler/twiceNestedKeyofIndexInference.ts.md
@@ -583,7 +583,7 @@ __ESTREE_TEST__:PASS:
                           "typeAnnotation": null
                         },
                         "nameType": null,
-                        "optional": null,
+                        "optional": false,
                         "readonly": null,
                         "typeAnnotation": {
                           "type": "TSTypeReference",

--- a/test-typescript/tests/cases/compiler/typeGuardNarrowByMutableUntypedField.ts.md
+++ b/test-typescript/tests/cases/compiler/typeGuardNarrowByMutableUntypedField.ts.md
@@ -123,7 +123,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSUnknownKeyword",

--- a/test-typescript/tests/cases/compiler/typeGuardNarrowByUntypedField.ts.md
+++ b/test-typescript/tests/cases/compiler/typeGuardNarrowByUntypedField.ts.md
@@ -123,7 +123,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": true,
               "typeAnnotation": {
                 "type": "TSUnknownKeyword",

--- a/test-typescript/tests/cases/compiler/typeGuardNarrowsIndexedAccessOfKnownProperty11.ts.md
+++ b/test-typescript/tests/cases/compiler/typeGuardNarrowsIndexedAccessOfKnownProperty11.ts.md
@@ -110,7 +110,7 @@ __ESTREE_TEST__:PASS:
                   "typeAnnotation": null
                 },
                 "nameType": null,
-                "optional": null,
+                "optional": false,
                 "readonly": null,
                 "typeAnnotation": {
                   "type": "TSUnionType",

--- a/test-typescript/tests/cases/compiler/typeGuardNarrowsIndexedAccessOfKnownProperty12.ts.md
+++ b/test-typescript/tests/cases/compiler/typeGuardNarrowsIndexedAccessOfKnownProperty12.ts.md
@@ -122,7 +122,7 @@ __ESTREE_TEST__:PASS:
                   "typeAnnotation": null
                 },
                 "nameType": null,
-                "optional": null,
+                "optional": false,
                 "readonly": null,
                 "typeAnnotation": {
                   "type": "TSUnionType",

--- a/test-typescript/tests/cases/compiler/typeParameterExtendsPrimitive.ts.md
+++ b/test-typescript/tests/cases/compiler/typeParameterExtendsPrimitive.ts.md
@@ -294,7 +294,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSIndexedAccessType",

--- a/test-typescript/tests/cases/compiler/typePredicateFreshLiteralWidening.ts.md
+++ b/test-typescript/tests/cases/compiler/typePredicateFreshLiteralWidening.ts.md
@@ -157,7 +157,7 @@ __ESTREE_TEST__:PASS:
               "typeAnnotation": null
             },
             "nameType": null,
-            "optional": null,
+            "optional": false,
             "readonly": null,
             "typeAnnotation": {
               "type": "TSTypeReference",

--- a/test-typescript/tests/cases/compiler/typeVariableConstraintIntersections.ts.md
+++ b/test-typescript/tests/cases/compiler/typeVariableConstraintIntersections.ts.md
@@ -4821,7 +4821,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSFunctionType",

--- a/test-typescript/tests/cases/compiler/undefinedAssignableToGenericMappedIntersection.ts.md
+++ b/test-typescript/tests/cases/compiler/undefinedAssignableToGenericMappedIntersection.ts.md
@@ -59,7 +59,7 @@ __ESTREE_TEST__:PASS:
               "typeAnnotation": null
             },
             "nameType": null,
-            "optional": null,
+            "optional": false,
             "readonly": null,
             "typeAnnotation": {
               "type": "TSUnionType",

--- a/test-typescript/tests/cases/compiler/unionPropertyOfProtectedAndIntersectionProperty.ts.md
+++ b/test-typescript/tests/cases/compiler/unionPropertyOfProtectedAndIntersectionProperty.ts.md
@@ -232,7 +232,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": true,
         "typeAnnotation": {
           "type": "TSConditionalType",

--- a/test-typescript/tests/cases/compiler/varianceProblingAndZeroOrderIndexSignatureRelationsAlign.ts.md
+++ b/test-typescript/tests/cases/compiler/varianceProblingAndZeroOrderIndexSignatureRelationsAlign.ts.md
@@ -2659,7 +2659,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSTypeReference",
@@ -2764,7 +2764,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSTypeReference",
@@ -2847,7 +2847,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSTypeReference",

--- a/test-typescript/tests/cases/compiler/varianceProblingAndZeroOrderIndexSignatureRelationsAlign2.ts.md
+++ b/test-typescript/tests/cases/compiler/varianceProblingAndZeroOrderIndexSignatureRelationsAlign2.ts.md
@@ -2659,7 +2659,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSTypeReference",
@@ -2764,7 +2764,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSTypeReference",
@@ -2847,7 +2847,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSTypeReference",

--- a/test-typescript/tests/cases/compiler/varianceRepeatedlyPropegatesWithUnreliableFlag.ts.md
+++ b/test-typescript/tests/cases/compiler/varianceRepeatedlyPropegatesWithUnreliableFlag.ts.md
@@ -188,7 +188,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSIndexedAccessType",

--- a/test-typescript/tests/cases/compiler/verbatim-declarations-parameters.ts.md
+++ b/test-typescript/tests/cases/compiler/verbatim-declarations-parameters.ts.md
@@ -49,7 +49,7 @@ __ESTREE_TEST__:PASS:
               "typeAnnotation": null
             },
             "nameType": null,
-            "optional": null,
+            "optional": false,
             "readonly": null,
             "typeAnnotation": {
               "type": "TSAnyKeyword",

--- a/test-typescript/tests/cases/compiler/vueLikeDataAndPropsInference.ts.md
+++ b/test-typescript/tests/cases/compiler/vueLikeDataAndPropsInference.ts.md
@@ -266,7 +266,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSIndexedAccessType",

--- a/test-typescript/tests/cases/compiler/vueLikeDataAndPropsInference2.ts.md
+++ b/test-typescript/tests/cases/compiler/vueLikeDataAndPropsInference2.ts.md
@@ -266,7 +266,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSIndexedAccessType",

--- a/test-typescript/tests/cases/conformance/classes/propertyMemberDeclarations/accessorsOverrideProperty8.ts.md
+++ b/test-typescript/tests/cases/conformance/classes/propertyMemberDeclarations/accessorsOverrideProperty8.ts.md
@@ -113,7 +113,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": true,
         "typeAnnotation": {
           "type": "TSConditionalType",

--- a/test-typescript/tests/cases/conformance/classes/propertyMemberDeclarations/accessorsOverrideProperty9.ts.md
+++ b/test-typescript/tests/cases/conformance/classes/propertyMemberDeclarations/accessorsOverrideProperty9.ts.md
@@ -175,7 +175,7 @@ __ESTREE_TEST__:PASS:
             "typeAnnotation": null
           },
           "nameType": null,
-          "optional": null,
+          "optional": false,
           "readonly": null,
           "typeAnnotation": {
             "type": "TSIndexedAccessType",

--- a/test-typescript/tests/cases/conformance/controlFlow/controlFlowGenericTypes.ts.md
+++ b/test-typescript/tests/cases/conformance/controlFlow/controlFlowGenericTypes.ts.md
@@ -6093,7 +6093,7 @@ __ESTREE_TEST__:PASS:
             "typeAnnotation": null
           },
           "nameType": null,
-          "optional": null,
+          "optional": false,
           "readonly": null,
           "typeAnnotation": {
             "type": "TSUnknownKeyword",

--- a/test-typescript/tests/cases/conformance/controlFlow/dependentDestructuredVariablesFromNestedPatterns.ts.md
+++ b/test-typescript/tests/cases/conformance/controlFlow/dependentDestructuredVariablesFromNestedPatterns.ts.md
@@ -731,7 +731,7 @@ __ESTREE_TEST__:PASS:
                   "typeAnnotation": null
                 },
                 "nameType": null,
-                "optional": null,
+                "optional": false,
                 "readonly": null,
                 "typeAnnotation": {
                   "type": "TSUnionType",

--- a/test-typescript/tests/cases/conformance/controlFlow/typeGuardsTypeParameters.ts.md
+++ b/test-typescript/tests/cases/conformance/controlFlow/typeGuardsTypeParameters.ts.md
@@ -871,7 +871,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSIndexedAccessType",

--- a/test-typescript/tests/cases/conformance/expressions/assignmentOperator/assignmentGenericLookupTypeNarrowing.ts.md
+++ b/test-typescript/tests/cases/conformance/expressions/assignmentOperator/assignmentGenericLookupTypeNarrowing.ts.md
@@ -52,7 +52,7 @@ __ESTREE_TEST__:PASS:
                   "typeAnnotation": null
                 },
                 "nameType": null,
-                "optional": null,
+                "optional": false,
                 "readonly": null,
                 "typeAnnotation": {
                   "type": "TSUnionType",

--- a/test-typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceExtendsObjectIntersection.ts.md
+++ b/test-typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceExtendsObjectIntersection.ts.md
@@ -359,7 +359,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSStringKeyword",

--- a/test-typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceExtendsObjectIntersectionErrors.ts.md
+++ b/test-typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceExtendsObjectIntersectionErrors.ts.md
@@ -261,7 +261,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSStringKeyword",

--- a/test-typescript/tests/cases/conformance/jsx/tsxLibraryManagedAttributes.tsx.md
+++ b/test-typescript/tests/cases/conformance/jsx/tsxLibraryManagedAttributes.tsx.md
@@ -216,7 +216,7 @@ __ESTREE_TEST__:PASS:
               "typeAnnotation": null
             },
             "nameType": null,
-            "optional": null,
+            "optional": false,
             "readonly": null,
             "typeAnnotation": {
               "type": "TSIndexedAccessType",
@@ -387,7 +387,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSConditionalType",

--- a/test-typescript/tests/cases/conformance/moduleResolution/resolutionModeImportType1.ts.md
+++ b/test-typescript/tests/cases/conformance/moduleResolution/resolutionModeImportType1.ts.md
@@ -228,7 +228,7 @@ __ESTREE_TEST__:PASS:
                   "start": 76,
                   "end": 82,
                   "decorators": [],
-                  "name": "with",
+                  "name": "assert",
                   "optional": false,
                   "typeAnnotation": null
                 },
@@ -334,7 +334,7 @@ __ESTREE_TEST__:PASS:
                   "start": 160,
                   "end": 166,
                   "decorators": [],
-                  "name": "with",
+                  "name": "assert",
                   "optional": false,
                   "typeAnnotation": null
                 },
@@ -440,7 +440,7 @@ __ESTREE_TEST__:PASS:
                   "start": 342,
                   "end": 348,
                   "decorators": [],
-                  "name": "with",
+                  "name": "assert",
                   "optional": false,
                   "typeAnnotation": null
                 },
@@ -546,7 +546,7 @@ __ESTREE_TEST__:PASS:
                   "start": 438,
                   "end": 444,
                   "decorators": [],
-                  "name": "with",
+                  "name": "assert",
                   "optional": false,
                   "typeAnnotation": null
                 },

--- a/test-typescript/tests/cases/conformance/node/nodeModulesImportTypeModeDeclarationEmit1.ts.md
+++ b/test-typescript/tests/cases/conformance/node/nodeModulesImportTypeModeDeclarationEmit1.ts.md
@@ -148,7 +148,7 @@ __ESTREE_TEST__:PASS:
                       "start": 51,
                       "end": 57,
                       "decorators": [],
-                      "name": "with",
+                      "name": "assert",
                       "optional": false,
                       "typeAnnotation": null
                     },
@@ -232,7 +232,7 @@ __ESTREE_TEST__:PASS:
                       "start": 132,
                       "end": 138,
                       "decorators": [],
-                      "name": "with",
+                      "name": "assert",
                       "optional": false,
                       "typeAnnotation": null
                     },
@@ -369,7 +369,7 @@ __ESTREE_TEST__:PASS:
                         "start": 240,
                         "end": 246,
                         "decorators": [],
-                        "name": "with",
+                        "name": "assert",
                         "optional": false,
                         "typeAnnotation": null
                       },
@@ -508,7 +508,7 @@ __ESTREE_TEST__:PASS:
                         "start": 350,
                         "end": 356,
                         "decorators": [],
-                        "name": "with",
+                        "name": "assert",
                         "optional": false,
                         "typeAnnotation": null
                       },

--- a/test-typescript/tests/cases/conformance/salsa/inferingFromAny.ts.md
+++ b/test-typescript/tests/cases/conformance/salsa/inferingFromAny.ts.md
@@ -2399,7 +2399,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSTypeReference",
@@ -2545,7 +2545,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSIndexedAccessType",

--- a/test-typescript/tests/cases/conformance/types/conditional/conditionalTypes1.ts.md
+++ b/test-typescript/tests/cases/conformance/types/conditional/conditionalTypes1.ts.md
@@ -3194,7 +3194,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSTypeReference",
@@ -4255,7 +4255,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSTypeReference",
@@ -4760,7 +4760,7 @@ __ESTREE_TEST__:PASS:
             "typeAnnotation": null
           },
           "nameType": null,
-          "optional": null,
+          "optional": false,
           "readonly": null,
           "typeAnnotation": {
             "type": "TSConditionalType",
@@ -5053,7 +5053,7 @@ __ESTREE_TEST__:PASS:
             "typeAnnotation": null
           },
           "nameType": null,
-          "optional": null,
+          "optional": false,
           "readonly": null,
           "typeAnnotation": {
             "type": "TSConditionalType",
@@ -6465,7 +6465,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": true,
         "typeAnnotation": {
           "type": "TSTypeReference",
@@ -16370,7 +16370,7 @@ __ESTREE_TEST__:PASS:
                   "typeAnnotation": null
                 },
                 "nameType": null,
-                "optional": null,
+                "optional": false,
                 "readonly": null,
                 "typeAnnotation": {
                   "type": "TSTypeReference",
@@ -16581,7 +16581,7 @@ __ESTREE_TEST__:PASS:
                   "typeAnnotation": null
                 },
                 "nameType": null,
-                "optional": null,
+                "optional": false,
                 "readonly": null,
                 "typeAnnotation": {
                   "type": "TSTypeReference",
@@ -17040,7 +17040,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSTypeReference",
@@ -17087,7 +17087,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSNeverKeyword",
@@ -18558,7 +18558,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSConditionalType",

--- a/test-typescript/tests/cases/conformance/types/conditional/conditionalTypes2.ts.md
+++ b/test-typescript/tests/cases/conformance/types/conditional/conditionalTypes2.ts.md
@@ -5365,7 +5365,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSConditionalType",
@@ -5464,7 +5464,7 @@ __ESTREE_TEST__:PASS:
             "typeAnnotation": null
           },
           "nameType": null,
-          "optional": null,
+          "optional": false,
           "readonly": null,
           "typeAnnotation": {
             "type": "TSTypeReference",
@@ -5776,7 +5776,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSConditionalType",
@@ -5875,7 +5875,7 @@ __ESTREE_TEST__:PASS:
             "typeAnnotation": null
           },
           "nameType": null,
-          "optional": null,
+          "optional": false,
           "readonly": null,
           "typeAnnotation": {
             "type": "TSTypeReference",
@@ -6074,7 +6074,7 @@ __ESTREE_TEST__:PASS:
               "typeAnnotation": null
             },
             "nameType": null,
-            "optional": null,
+            "optional": false,
             "readonly": null,
             "typeAnnotation": {
               "type": "TSConditionalType",
@@ -6173,7 +6173,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSTypeReference",
@@ -6444,7 +6444,7 @@ __ESTREE_TEST__:PASS:
               "typeAnnotation": null
             },
             "nameType": null,
-            "optional": null,
+            "optional": false,
             "readonly": null,
             "typeAnnotation": {
               "type": "TSTypeReference",
@@ -6732,7 +6732,7 @@ __ESTREE_TEST__:PASS:
               "typeAnnotation": null
             },
             "nameType": null,
-            "optional": null,
+            "optional": false,
             "readonly": null,
             "typeAnnotation": {
               "type": "TSTypeReference",
@@ -6957,7 +6957,7 @@ __ESTREE_TEST__:PASS:
             "typeAnnotation": null
           },
           "nameType": null,
-          "optional": null,
+          "optional": false,
           "readonly": null,
           "typeAnnotation": {
             "type": "TSTypeReference",
@@ -7929,7 +7929,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSTypeReference",
@@ -8124,7 +8124,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSTypeReference",
@@ -8355,7 +8355,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSTypeReference",
@@ -8581,7 +8581,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSTypeReference",
@@ -8888,7 +8888,7 @@ __ESTREE_TEST__:PASS:
             "typeAnnotation": null
           },
           "nameType": null,
-          "optional": null,
+          "optional": false,
           "readonly": null,
           "typeAnnotation": {
             "type": "TSNumberKeyword",
@@ -10043,7 +10043,7 @@ __ESTREE_TEST__:PASS:
             "typeAnnotation": null
           },
           "nameType": null,
-          "optional": null,
+          "optional": false,
           "readonly": null,
           "typeAnnotation": {
             "type": "TSConditionalType",
@@ -10919,7 +10919,7 @@ __ESTREE_TEST__:PASS:
                     "typeAnnotation": null
                   },
                   "nameType": null,
-                  "optional": null,
+                  "optional": false,
                   "readonly": null,
                   "typeAnnotation": {
                     "type": "TSLiteralType",

--- a/test-typescript/tests/cases/conformance/types/conditional/inferTypes1.ts.md
+++ b/test-typescript/tests/cases/conformance/types/conditional/inferTypes1.ts.md
@@ -7673,7 +7673,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSTypeReference",
@@ -9608,7 +9608,7 @@ __ESTREE_TEST__:PASS:
             "typeAnnotation": null
           },
           "nameType": null,
-          "optional": null,
+          "optional": false,
           "readonly": null,
           "typeAnnotation": {
             "type": "TSVoidKeyword",
@@ -9726,7 +9726,7 @@ __ESTREE_TEST__:PASS:
             "typeAnnotation": null
           },
           "nameType": null,
-          "optional": null,
+          "optional": false,
           "readonly": null,
           "typeAnnotation": {
             "type": "TSVoidKeyword",

--- a/test-typescript/tests/cases/conformance/types/conditional/inferTypes2.ts.md
+++ b/test-typescript/tests/cases/conformance/types/conditional/inferTypes2.ts.md
@@ -560,7 +560,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSIndexedAccessType",

--- a/test-typescript/tests/cases/conformance/types/conditional/inferTypesWithExtends1.ts.md
+++ b/test-typescript/tests/cases/conformance/types/conditional/inferTypesWithExtends1.ts.md
@@ -6557,7 +6557,7 @@ __ESTREE_TEST__:PASS:
             "typeAnnotation": null
           },
           "nameType": null,
-          "optional": null,
+          "optional": false,
           "readonly": null,
           "typeAnnotation": {
             "type": "TSLiteralType",
@@ -6715,7 +6715,7 @@ __ESTREE_TEST__:PASS:
             "typeAnnotation": null
           },
           "nameType": null,
-          "optional": null,
+          "optional": false,
           "readonly": null,
           "typeAnnotation": {
             "type": "TSLiteralType",
@@ -6917,7 +6917,7 @@ __ESTREE_TEST__:PASS:
               }
             }
           },
-          "optional": null,
+          "optional": false,
           "readonly": null,
           "typeAnnotation": {
             "type": "TSLiteralType",
@@ -7089,7 +7089,7 @@ __ESTREE_TEST__:PASS:
               "out": false
             }
           },
-          "optional": null,
+          "optional": false,
           "readonly": null,
           "typeAnnotation": {
             "type": "TSLiteralType",

--- a/test-typescript/tests/cases/conformance/types/intersection/intersectionAsWeakTypeSource.ts.md
+++ b/test-typescript/tests/cases/conformance/types/intersection/intersectionAsWeakTypeSource.ts.md
@@ -639,7 +639,7 @@ __ESTREE_TEST__:PASS:
             "typeAnnotation": null
           },
           "nameType": null,
-          "optional": null,
+          "optional": false,
           "readonly": null,
           "typeAnnotation": {
             "type": "TSTypeReference",

--- a/test-typescript/tests/cases/conformance/types/intersection/intersectionReduction.ts.md
+++ b/test-typescript/tests/cases/conformance/types/intersection/intersectionReduction.ts.md
@@ -2589,7 +2589,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSConditionalType",
@@ -2854,7 +2854,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSConditionalType",

--- a/test-typescript/tests/cases/conformance/types/intersection/intersectionReductionStrict.ts.md
+++ b/test-typescript/tests/cases/conformance/types/intersection/intersectionReductionStrict.ts.md
@@ -2589,7 +2589,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSConditionalType",
@@ -2854,7 +2854,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSConditionalType",

--- a/test-typescript/tests/cases/conformance/types/intersection/intersectionTypeInference2.ts.md
+++ b/test-typescript/tests/cases/conformance/types/intersection/intersectionTypeInference2.ts.md
@@ -447,7 +447,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSIndexedAccessType",

--- a/test-typescript/tests/cases/conformance/types/intersection/intersectionWithIndexSignatures.ts.md
+++ b/test-typescript/tests/cases/conformance/types/intersection/intersectionWithIndexSignatures.ts.md
@@ -1002,7 +1002,7 @@ __ESTREE_TEST__:PASS:
               "typeAnnotation": null
             },
             "nameType": null,
-            "optional": null,
+            "optional": false,
             "readonly": null,
             "typeAnnotation": {
               "type": "TSStringKeyword",

--- a/test-typescript/tests/cases/conformance/types/intersection/intersectionWithUnionConstraint.ts.md
+++ b/test-typescript/tests/cases/conformance/types/intersection/intersectionWithUnionConstraint.ts.md
@@ -1366,7 +1366,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSConditionalType",
@@ -1886,7 +1886,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSLiteralType",

--- a/test-typescript/tests/cases/conformance/types/intersection/intersectionsAndEmptyObjects.ts.md
+++ b/test-typescript/tests/cases/conformance/types/intersection/intersectionsAndEmptyObjects.ts.md
@@ -2991,7 +2991,7 @@ __ESTREE_TEST__:PASS:
               "typeAnnotation": null
             },
             "nameType": null,
-            "optional": null,
+            "optional": false,
             "readonly": null,
             "typeAnnotation": {
               "type": "TSTypeReference",

--- a/test-typescript/tests/cases/conformance/types/keyof/keyofAndForIn.ts.md
+++ b/test-typescript/tests/cases/conformance/types/keyof/keyofAndForIn.ts.md
@@ -336,7 +336,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSTypeReference",
@@ -779,7 +779,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSIndexedAccessType",
@@ -1213,7 +1213,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSIndexedAccessType",

--- a/test-typescript/tests/cases/conformance/types/keyof/keyofAndIndexedAccess.ts.md
+++ b/test-typescript/tests/cases/conformance/types/keyof/keyofAndIndexedAccess.ts.md
@@ -19392,7 +19392,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSFunctionType",
@@ -21829,7 +21829,7 @@ __ESTREE_TEST__:PASS:
                   "typeAnnotation": null
                 },
                 "nameType": null,
-                "optional": null,
+                "optional": false,
                 "readonly": null,
                 "typeAnnotation": {
                   "type": "TSArrayType",
@@ -23784,7 +23784,7 @@ __ESTREE_TEST__:PASS:
                   "typeAnnotation": null
                 },
                 "nameType": null,
-                "optional": null,
+                "optional": false,
                 "readonly": null,
                 "typeAnnotation": {
                   "type": "TSFunctionType",
@@ -25493,7 +25493,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSFunctionType",
@@ -25694,7 +25694,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSIndexedAccessType",
@@ -25794,7 +25794,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSTypeLiteral",
@@ -26062,7 +26062,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSTypeReference",
@@ -26254,7 +26254,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSIndexedAccessType",
@@ -26560,7 +26560,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSUnionType",
@@ -28311,7 +28311,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSNumberKeyword",
@@ -28393,7 +28393,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSTypeReference",
@@ -29297,7 +29297,7 @@ __ESTREE_TEST__:PASS:
                           "typeAnnotation": null
                         },
                         "nameType": null,
-                        "optional": null,
+                        "optional": false,
                         "readonly": null,
                         "typeAnnotation": {
                           "type": "TSStringKeyword",
@@ -29643,7 +29643,7 @@ __ESTREE_TEST__:PASS:
                       "typeAnnotation": null
                     },
                     "nameType": null,
-                    "optional": null,
+                    "optional": false,
                     "readonly": null,
                     "typeAnnotation": {
                       "type": "TSStringKeyword",

--- a/test-typescript/tests/cases/conformance/types/keyof/keyofAndIndexedAccess2.ts.md
+++ b/test-typescript/tests/cases/conformance/types/keyof/keyofAndIndexedAccess2.ts.md
@@ -1664,7 +1664,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSNumberKeyword",
@@ -1918,7 +1918,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSNumberKeyword",
@@ -1958,7 +1958,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSNumberKeyword",
@@ -5287,7 +5287,7 @@ __ESTREE_TEST__:PASS:
               "typeAnnotation": null
             },
             "nameType": null,
-            "optional": null,
+            "optional": false,
             "readonly": null,
             "typeAnnotation": {
               "type": "TSTypeReference",
@@ -5316,7 +5316,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSIndexedAccessType",
@@ -5439,7 +5439,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSTypeReference",
@@ -6918,7 +6918,7 @@ __ESTREE_TEST__:PASS:
                     "typeAnnotation": null
                   },
                   "nameType": null,
-                  "optional": null,
+                  "optional": false,
                   "readonly": null,
                   "typeAnnotation": {
                     "type": "TSTypeReference",
@@ -7078,7 +7078,7 @@ __ESTREE_TEST__:PASS:
                     "typeAnnotation": null
                   },
                   "nameType": null,
-                  "optional": null,
+                  "optional": false,
                   "readonly": null,
                   "typeAnnotation": {
                     "type": "TSTupleType",
@@ -7184,7 +7184,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSIndexedAccessType",
@@ -7372,7 +7372,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSIndexedAccessType",

--- a/test-typescript/tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts.md
+++ b/test-typescript/tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts.md
@@ -4800,7 +4800,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSStringKeyword",
@@ -4873,7 +4873,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSConditionalType",

--- a/test-typescript/tests/cases/conformance/types/literal/numericStringLiteralTypes.ts.md
+++ b/test-typescript/tests/cases/conformance/types/literal/numericStringLiteralTypes.ts.md
@@ -1043,7 +1043,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSTypeReference",
@@ -1254,7 +1254,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSIndexedAccessType",

--- a/test-typescript/tests/cases/conformance/types/literal/templateLiteralTypes1.ts.md
+++ b/test-typescript/tests/cases/conformance/types/literal/templateLiteralTypes1.ts.md
@@ -1969,7 +1969,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSIndexedAccessType",
@@ -2110,7 +2110,7 @@ __ESTREE_TEST__:PASS:
                   }
                 ]
               },
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSIndexedAccessType",
@@ -2347,7 +2347,7 @@ __ESTREE_TEST__:PASS:
                   }
                 ]
               },
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSTypeReference",
@@ -2450,7 +2450,7 @@ __ESTREE_TEST__:PASS:
                   }
                 ]
               },
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSTypeReference",

--- a/test-typescript/tests/cases/conformance/types/literal/templateLiteralTypes4.ts.md
+++ b/test-typescript/tests/cases/conformance/types/literal/templateLiteralTypes4.ts.md
@@ -13994,7 +13994,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSTypeReference",
@@ -14283,7 +14283,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSTypeReference",

--- a/test-typescript/tests/cases/conformance/types/mapped/isomorphicMappedTypeInference.ts.md
+++ b/test-typescript/tests/cases/conformance/types/mapped/isomorphicMappedTypeInference.ts.md
@@ -141,7 +141,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSTypeReference",
@@ -2666,7 +2666,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSTypeReference",
@@ -3800,7 +3800,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": true,
               "typeAnnotation": {
                 "type": "TSIndexedAccessType",
@@ -4482,7 +4482,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSUnionType",

--- a/test-typescript/tests/cases/conformance/types/mapped/mappedTypeAsClauseRelationships.ts.md
+++ b/test-typescript/tests/cases/conformance/types/mapped/mappedTypeAsClauseRelationships.ts.md
@@ -128,7 +128,7 @@ __ESTREE_TEST__:PASS:
             }
           }
         },
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSIndexedAccessType",
@@ -419,7 +419,7 @@ __ESTREE_TEST__:PASS:
             }
           }
         },
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSIndexedAccessType",
@@ -616,7 +616,7 @@ __ESTREE_TEST__:PASS:
             ]
           }
         },
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSIndexedAccessType",

--- a/test-typescript/tests/cases/conformance/types/mapped/mappedTypeAsClauses.ts.md
+++ b/test-typescript/tests/cases/conformance/types/mapped/mappedTypeAsClauses.ts.md
@@ -130,7 +130,7 @@ __ESTREE_TEST__:PASS:
             }
           ]
         },
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSFunctionType",
@@ -598,7 +598,7 @@ __ESTREE_TEST__:PASS:
             }
           }
         },
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSIndexedAccessType",
@@ -1180,7 +1180,7 @@ __ESTREE_TEST__:PASS:
             }
           }
         },
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSIndexedAccessType",
@@ -1568,7 +1568,7 @@ __ESTREE_TEST__:PASS:
             }
           ]
         },
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSIndexedAccessType",
@@ -2082,7 +2082,7 @@ __ESTREE_TEST__:PASS:
             }
           ]
         },
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSFunctionType",
@@ -2526,7 +2526,7 @@ __ESTREE_TEST__:PASS:
             }
           }
         },
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSIndexedAccessType",
@@ -3346,7 +3346,7 @@ __ESTREE_TEST__:PASS:
             }
           }
         },
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSIndexedAccessType",
@@ -4282,7 +4282,7 @@ __ESTREE_TEST__:PASS:
               }
             }
           },
-          "optional": null,
+          "optional": false,
           "readonly": null,
           "typeAnnotation": {
             "type": "TSAnyKeyword",
@@ -4502,7 +4502,7 @@ __ESTREE_TEST__:PASS:
               "typeAnnotation": null
             }
           },
-          "optional": null,
+          "optional": false,
           "readonly": null,
           "typeAnnotation": {
             "type": "TSAnyKeyword",
@@ -4717,7 +4717,7 @@ __ESTREE_TEST__:PASS:
             "typeAnnotation": null
           }
         },
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSAnyKeyword",
@@ -5421,7 +5421,7 @@ __ESTREE_TEST__:PASS:
               }
             }
           },
-          "optional": null,
+          "optional": false,
           "readonly": null,
           "typeAnnotation": {
             "type": "TSIndexedAccessType",
@@ -5941,7 +5941,7 @@ __ESTREE_TEST__:PASS:
               }
             }
           },
-          "optional": null,
+          "optional": false,
           "readonly": null,
           "typeAnnotation": {
             "type": "TSStringKeyword",
@@ -6109,7 +6109,7 @@ __ESTREE_TEST__:PASS:
               "typeAnnotation": null
             }
           },
-          "optional": null,
+          "optional": false,
           "readonly": null,
           "typeAnnotation": {
             "type": "TSStringKeyword",
@@ -6263,7 +6263,7 @@ __ESTREE_TEST__:PASS:
               }
             ]
           },
-          "optional": null,
+          "optional": false,
           "readonly": null,
           "typeAnnotation": {
             "type": "TSStringKeyword",
@@ -6431,7 +6431,7 @@ __ESTREE_TEST__:PASS:
               "typeAnnotation": null
             }
           },
-          "optional": null,
+          "optional": false,
           "readonly": null,
           "typeAnnotation": {
             "type": "TSStringKeyword",
@@ -6583,7 +6583,7 @@ __ESTREE_TEST__:PASS:
               }
             }
           },
-          "optional": null,
+          "optional": false,
           "readonly": null,
           "typeAnnotation": {
             "type": "TSStringKeyword",
@@ -6735,7 +6735,7 @@ __ESTREE_TEST__:PASS:
               }
             }
           },
-          "optional": null,
+          "optional": false,
           "readonly": null,
           "typeAnnotation": {
             "type": "TSStringKeyword",
@@ -6901,7 +6901,7 @@ __ESTREE_TEST__:PASS:
               }
             ]
           },
-          "optional": null,
+          "optional": false,
           "readonly": null,
           "typeAnnotation": {
             "type": "TSStringKeyword",
@@ -7093,7 +7093,7 @@ __ESTREE_TEST__:PASS:
               }
             }
           },
-          "optional": null,
+          "optional": false,
           "readonly": null,
           "typeAnnotation": {
             "type": "TSStringKeyword",
@@ -7247,7 +7247,7 @@ __ESTREE_TEST__:PASS:
               }
             }
           },
-          "optional": null,
+          "optional": false,
           "readonly": null,
           "typeAnnotation": {
             "type": "TSStringKeyword",
@@ -7392,7 +7392,7 @@ __ESTREE_TEST__:PASS:
               }
             }
           },
-          "optional": null,
+          "optional": false,
           "readonly": null,
           "typeAnnotation": {
             "type": "TSStringKeyword",
@@ -7595,7 +7595,7 @@ __ESTREE_TEST__:PASS:
               "typeAnnotation": null
             }
           },
-          "optional": null,
+          "optional": false,
           "readonly": null,
           "typeAnnotation": {
             "type": "TSStringKeyword",
@@ -7819,7 +7819,7 @@ __ESTREE_TEST__:PASS:
               }
             }
           },
-          "optional": null,
+          "optional": false,
           "readonly": null,
           "typeAnnotation": {
             "type": "TSStringKeyword",
@@ -8035,7 +8035,7 @@ __ESTREE_TEST__:PASS:
                   }
                 }
               },
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSLiteralType",
@@ -8051,7 +8051,7 @@ __ESTREE_TEST__:PASS:
               }
             }
           },
-          "optional": null,
+          "optional": false,
           "readonly": null,
           "typeAnnotation": {
             "type": "TSStringKeyword",
@@ -8511,7 +8511,7 @@ __ESTREE_TEST__:PASS:
             }
           ]
         },
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSUnknownKeyword",
@@ -8784,7 +8784,7 @@ __ESTREE_TEST__:PASS:
               }
             ]
           },
-          "optional": null,
+          "optional": false,
           "readonly": null,
           "typeAnnotation": {
             "type": "TSUnknownKeyword",

--- a/test-typescript/tests/cases/conformance/types/mapped/mappedTypeConstraints2.ts.md
+++ b/test-typescript/tests/cases/conformance/types/mapped/mappedTypeConstraints2.ts.md
@@ -48,7 +48,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSTypeLiteral",
@@ -448,7 +448,7 @@ __ESTREE_TEST__:PASS:
             }
           ]
         },
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSTypeLiteral",
@@ -869,7 +869,7 @@ __ESTREE_TEST__:PASS:
             "typeAnnotation": null
           }
         },
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSTypeLiteral",
@@ -1247,7 +1247,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSTypeReference",
@@ -1719,7 +1719,7 @@ __ESTREE_TEST__:PASS:
             }
           }
         },
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSTypeReference",
@@ -2103,7 +2103,7 @@ __ESTREE_TEST__:PASS:
             }
           ]
         },
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSTypeReference",
@@ -2487,7 +2487,7 @@ __ESTREE_TEST__:PASS:
             }
           ]
         },
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSTypeReference",
@@ -2959,7 +2959,7 @@ __ESTREE_TEST__:PASS:
             }
           }
         },
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSTypeReference",
@@ -3617,7 +3617,7 @@ __ESTREE_TEST__:PASS:
             }
           ]
         },
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSLiteralType",

--- a/test-typescript/tests/cases/conformance/types/mapped/mappedTypeErrors.ts.md
+++ b/test-typescript/tests/cases/conformance/types/mapped/mappedTypeErrors.ts.md
@@ -323,7 +323,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSStringKeyword",
@@ -366,7 +366,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSStringKeyword",
@@ -419,7 +419,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSNumberKeyword",
@@ -1764,7 +1764,7 @@ __ESTREE_TEST__:PASS:
                         "typeAnnotation": null
                       },
                       "nameType": null,
-                      "optional": null,
+                      "optional": false,
                       "readonly": null,
                       "typeAnnotation": {
                         "type": "TSIndexedAccessType",
@@ -1866,7 +1866,7 @@ __ESTREE_TEST__:PASS:
                         "typeAnnotation": null
                       },
                       "nameType": null,
-                      "optional": null,
+                      "optional": false,
                       "readonly": null,
                       "typeAnnotation": {
                         "type": "TSIndexedAccessType",
@@ -1962,7 +1962,7 @@ __ESTREE_TEST__:PASS:
                         "typeAnnotation": null
                       },
                       "nameType": null,
-                      "optional": null,
+                      "optional": false,
                       "readonly": null,
                       "typeAnnotation": {
                         "type": "TSIndexedAccessType",
@@ -2117,7 +2117,7 @@ __ESTREE_TEST__:PASS:
                         "typeAnnotation": null
                       },
                       "nameType": null,
-                      "optional": null,
+                      "optional": false,
                       "readonly": null,
                       "typeAnnotation": {
                         "type": "TSIndexedAccessType",
@@ -2321,7 +2321,7 @@ __ESTREE_TEST__:PASS:
                         "typeAnnotation": null
                       },
                       "nameType": null,
-                      "optional": null,
+                      "optional": false,
                       "readonly": true,
                       "typeAnnotation": {
                         "type": "TSIndexedAccessType",
@@ -2578,7 +2578,7 @@ __ESTREE_TEST__:PASS:
                         "typeAnnotation": null
                       },
                       "nameType": null,
-                      "optional": null,
+                      "optional": false,
                       "readonly": null,
                       "typeAnnotation": {
                         "type": "TSIndexedAccessType",
@@ -2680,7 +2680,7 @@ __ESTREE_TEST__:PASS:
                         "typeAnnotation": null
                       },
                       "nameType": null,
-                      "optional": null,
+                      "optional": false,
                       "readonly": null,
                       "typeAnnotation": {
                         "type": "TSArrayType",
@@ -6234,7 +6234,7 @@ __ESTREE_TEST__:PASS:
                   "typeAnnotation": null
                 },
                 "nameType": null,
-                "optional": null,
+                "optional": false,
                 "readonly": null,
                 "typeAnnotation": {
                   "type": "TSIndexedAccessType",

--- a/test-typescript/tests/cases/conformance/types/mapped/mappedTypeErrors2.ts.md
+++ b/test-typescript/tests/cases/conformance/types/mapped/mappedTypeErrors2.ts.md
@@ -163,7 +163,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSLiteralType",
@@ -452,7 +452,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSLiteralType",
@@ -657,7 +657,7 @@ __ESTREE_TEST__:PASS:
             "typeAnnotation": null
           },
           "nameType": null,
-          "optional": null,
+          "optional": false,
           "readonly": null,
           "typeAnnotation": {
             "type": "TSLiteralType",
@@ -824,7 +824,7 @@ __ESTREE_TEST__:PASS:
             "typeAnnotation": null
           },
           "nameType": null,
-          "optional": null,
+          "optional": false,
           "readonly": null,
           "typeAnnotation": {
             "type": "TSLiteralType",
@@ -1028,7 +1028,7 @@ __ESTREE_TEST__:PASS:
             "typeAnnotation": null
           },
           "nameType": null,
-          "optional": null,
+          "optional": false,
           "readonly": null,
           "typeAnnotation": {
             "type": "TSLiteralType",

--- a/test-typescript/tests/cases/conformance/types/mapped/mappedTypeIndexSignatureModifiers.ts.md
+++ b/test-typescript/tests/cases/conformance/types/mapped/mappedTypeIndexSignatureModifiers.ts.md
@@ -900,7 +900,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSIndexedAccessType",
@@ -1534,7 +1534,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": "-",
         "typeAnnotation": {
           "type": "TSIndexedAccessType",
@@ -2362,7 +2362,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": "-",
         "typeAnnotation": {
           "type": "TSIndexedAccessType",

--- a/test-typescript/tests/cases/conformance/types/mapped/mappedTypeInferenceErrors.ts.md
+++ b/test-typescript/tests/cases/conformance/types/mapped/mappedTypeInferenceErrors.ts.md
@@ -54,7 +54,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSFunctionType",

--- a/test-typescript/tests/cases/conformance/types/mapped/mappedTypeModifiers.ts.md
+++ b/test-typescript/tests/cases/conformance/types/mapped/mappedTypeModifiers.ts.md
@@ -689,7 +689,7 @@ __ESTREE_TEST__:PASS:
                   "typeAnnotation": null
                 },
                 "nameType": null,
-                "optional": null,
+                "optional": false,
                 "readonly": null,
                 "typeAnnotation": {
                   "type": "TSIndexedAccessType",
@@ -1216,7 +1216,7 @@ __ESTREE_TEST__:PASS:
                   "typeAnnotation": null
                 },
                 "nameType": null,
-                "optional": null,
+                "optional": false,
                 "readonly": null,
                 "typeAnnotation": {
                   "type": "TSIndexedAccessType",
@@ -1448,7 +1448,7 @@ __ESTREE_TEST__:PASS:
                   "typeAnnotation": null
                 },
                 "nameType": null,
-                "optional": null,
+                "optional": false,
                 "readonly": true,
                 "typeAnnotation": {
                   "type": "TSIndexedAccessType",
@@ -1615,7 +1615,7 @@ __ESTREE_TEST__:PASS:
                   "typeAnnotation": null
                 },
                 "nameType": null,
-                "optional": null,
+                "optional": false,
                 "readonly": null,
                 "typeAnnotation": {
                   "type": "TSIndexedAccessType",
@@ -2251,7 +2251,7 @@ __ESTREE_TEST__:PASS:
                   "typeAnnotation": null
                 },
                 "nameType": null,
-                "optional": null,
+                "optional": false,
                 "readonly": null,
                 "typeAnnotation": {
                   "type": "TSIndexedAccessType",
@@ -2432,7 +2432,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSTypeLiteral",
@@ -3460,7 +3460,7 @@ __ESTREE_TEST__:PASS:
                   "typeAnnotation": null
                 },
                 "nameType": null,
-                "optional": null,
+                "optional": false,
                 "readonly": null,
                 "typeAnnotation": {
                   "type": "TSIndexedAccessType",
@@ -3987,7 +3987,7 @@ __ESTREE_TEST__:PASS:
                   "typeAnnotation": null
                 },
                 "nameType": null,
-                "optional": null,
+                "optional": false,
                 "readonly": null,
                 "typeAnnotation": {
                   "type": "TSIndexedAccessType",
@@ -4219,7 +4219,7 @@ __ESTREE_TEST__:PASS:
                   "typeAnnotation": null
                 },
                 "nameType": null,
-                "optional": null,
+                "optional": false,
                 "readonly": true,
                 "typeAnnotation": {
                   "type": "TSIndexedAccessType",
@@ -4386,7 +4386,7 @@ __ESTREE_TEST__:PASS:
                   "typeAnnotation": null
                 },
                 "nameType": null,
-                "optional": null,
+                "optional": false,
                 "readonly": null,
                 "typeAnnotation": {
                   "type": "TSIndexedAccessType",
@@ -5022,7 +5022,7 @@ __ESTREE_TEST__:PASS:
                   "typeAnnotation": null
                 },
                 "nameType": null,
-                "optional": null,
+                "optional": false,
                 "readonly": null,
                 "typeAnnotation": {
                   "type": "TSIndexedAccessType",
@@ -5914,7 +5914,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSIndexedAccessType",

--- a/test-typescript/tests/cases/conformance/types/mapped/mappedTypeOverlappingStringEnumKeys.ts.md
+++ b/test-typescript/tests/cases/conformance/types/mapped/mappedTypeOverlappingStringEnumKeys.ts.md
@@ -488,7 +488,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSArrayType",

--- a/test-typescript/tests/cases/conformance/types/mapped/mappedTypeRelationships.ts.md
+++ b/test-typescript/tests/cases/conformance/types/mapped/mappedTypeRelationships.ts.md
@@ -5784,7 +5784,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSIndexedAccessType",
@@ -5898,7 +5898,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSIndexedAccessType",
@@ -6224,7 +6224,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSIndexedAccessType",
@@ -6844,7 +6844,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSIndexedAccessType",
@@ -6930,7 +6930,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSIndexedAccessType",
@@ -7130,7 +7130,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSIndexedAccessType",
@@ -7216,7 +7216,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSIndexedAccessType",
@@ -7449,7 +7449,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSIndexedAccessType",
@@ -7535,7 +7535,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSIndexedAccessType",
@@ -7762,7 +7762,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSIndexedAccessType",
@@ -7848,7 +7848,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSIndexedAccessType",
@@ -8081,7 +8081,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSIndexedAccessType",
@@ -8167,7 +8167,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSIndexedAccessType",
@@ -8433,7 +8433,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSIndexedAccessType",
@@ -8519,7 +8519,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSIndexedAccessType",
@@ -8785,7 +8785,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSIndexedAccessType",
@@ -8865,7 +8865,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSIndexedAccessType",

--- a/test-typescript/tests/cases/conformance/types/mapped/mappedTypeWithAny.ts.md
+++ b/test-typescript/tests/cases/conformance/types/mapped/mappedTypeWithAny.ts.md
@@ -106,7 +106,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSTypeReference",
@@ -231,7 +231,7 @@ __ESTREE_TEST__:PASS:
                   "typeAnnotation": null
                 },
                 "nameType": null,
-                "optional": null,
+                "optional": false,
                 "readonly": null,
                 "typeAnnotation": {
                   "type": "TSTypeReference",
@@ -297,7 +297,7 @@ __ESTREE_TEST__:PASS:
                   "typeAnnotation": null
                 },
                 "nameType": null,
-                "optional": null,
+                "optional": false,
                 "readonly": null,
                 "typeAnnotation": {
                   "type": "TSTypeReference",
@@ -369,7 +369,7 @@ __ESTREE_TEST__:PASS:
                   "typeAnnotation": null
                 },
                 "nameType": null,
-                "optional": null,
+                "optional": false,
                 "readonly": null,
                 "typeAnnotation": {
                   "type": "TSTypeReference",
@@ -551,7 +551,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSTypeReference",
@@ -844,7 +844,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSIndexedAccessType",
@@ -967,7 +967,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSIndexedAccessType",
@@ -1484,7 +1484,7 @@ __ESTREE_TEST__:PASS:
             "typeAnnotation": null
           },
           "nameType": null,
-          "optional": null,
+          "optional": false,
           "readonly": "-",
           "typeAnnotation": {
             "type": "TSStringKeyword",
@@ -1702,7 +1702,7 @@ __ESTREE_TEST__:PASS:
             "typeAnnotation": null
           },
           "nameType": null,
-          "optional": null,
+          "optional": false,
           "readonly": "-",
           "typeAnnotation": {
             "type": "TSStringKeyword",
@@ -1896,7 +1896,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSNeverKeyword",
@@ -2015,7 +2015,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSNeverKeyword",

--- a/test-typescript/tests/cases/conformance/types/mapped/mappedTypes1.ts.md
+++ b/test-typescript/tests/cases/conformance/types/mapped/mappedTypes1.ts.md
@@ -174,7 +174,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSNumberKeyword",
@@ -243,7 +243,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSTypeReference",
@@ -322,7 +322,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSIndexedAccessType",
@@ -411,7 +411,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSTypeReference",
@@ -480,7 +480,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSIndexedAccessType",
@@ -658,7 +658,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": true,
         "typeAnnotation": {
           "type": "TSIndexedAccessType",
@@ -836,7 +836,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSUnionType",
@@ -937,7 +937,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSTypeReference",
@@ -1037,7 +1037,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSVoidKeyword",
@@ -1086,7 +1086,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSVoidKeyword",
@@ -1135,7 +1135,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSVoidKeyword",
@@ -1184,7 +1184,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSVoidKeyword",
@@ -1233,7 +1233,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSVoidKeyword",
@@ -1282,7 +1282,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSVoidKeyword",
@@ -1331,7 +1331,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSVoidKeyword",
@@ -1380,7 +1380,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSVoidKeyword",
@@ -1429,7 +1429,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSVoidKeyword",
@@ -1472,7 +1472,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSVoidKeyword",
@@ -1541,7 +1541,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSVoidKeyword",
@@ -1634,7 +1634,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSVoidKeyword",
@@ -1732,7 +1732,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSVoidKeyword",
@@ -1800,7 +1800,7 @@ __ESTREE_TEST__:PASS:
             "typeAnnotation": null
           },
           "nameType": null,
-          "optional": null,
+          "optional": false,
           "readonly": null,
           "typeAnnotation": {
             "type": "TSVoidKeyword",
@@ -1894,7 +1894,7 @@ __ESTREE_TEST__:PASS:
             "typeAnnotation": null
           },
           "nameType": null,
-          "optional": null,
+          "optional": false,
           "readonly": null,
           "typeAnnotation": {
             "type": "TSVoidKeyword",
@@ -1992,7 +1992,7 @@ __ESTREE_TEST__:PASS:
             "typeAnnotation": null
           },
           "nameType": null,
-          "optional": null,
+          "optional": false,
           "readonly": null,
           "typeAnnotation": {
             "type": "TSVoidKeyword",
@@ -2090,7 +2090,7 @@ __ESTREE_TEST__:PASS:
             "typeAnnotation": null
           },
           "nameType": null,
-          "optional": null,
+          "optional": false,
           "readonly": null,
           "typeAnnotation": {
             "type": "TSVoidKeyword",

--- a/test-typescript/tests/cases/conformance/types/mapped/mappedTypes2.ts.md
+++ b/test-typescript/tests/cases/conformance/types/mapped/mappedTypes2.ts.md
@@ -303,7 +303,7 @@ __ESTREE_TEST__:PASS:
                         "typeAnnotation": null
                       },
                       "nameType": null,
-                      "optional": null,
+                      "optional": false,
                       "readonly": true,
                       "typeAnnotation": {
                         "type": "TSIndexedAccessType",
@@ -479,7 +479,7 @@ __ESTREE_TEST__:PASS:
                         "typeAnnotation": null
                       },
                       "nameType": null,
-                      "optional": null,
+                      "optional": false,
                       "readonly": null,
                       "typeAnnotation": {
                         "type": "TSIndexedAccessType",
@@ -655,7 +655,7 @@ __ESTREE_TEST__:PASS:
                         "typeAnnotation": null
                       },
                       "nameType": null,
-                      "optional": null,
+                      "optional": false,
                       "readonly": null,
                       "typeAnnotation": {
                         "type": "TSTypeReference",
@@ -982,7 +982,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSTypeReference",
@@ -1117,7 +1117,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": true,
         "typeAnnotation": {
           "type": "TSTypeReference",

--- a/test-typescript/tests/cases/conformance/types/mapped/mappedTypes3.ts.md
+++ b/test-typescript/tests/cases/conformance/types/mapped/mappedTypes3.ts.md
@@ -151,7 +151,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSTypeReference",

--- a/test-typescript/tests/cases/conformance/types/mapped/mappedTypes4.ts.md
+++ b/test-typescript/tests/cases/conformance/types/mapped/mappedTypes4.ts.md
@@ -101,7 +101,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSTypeReference",
@@ -1445,7 +1445,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSUnionType",
@@ -1856,7 +1856,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": true,
         "typeAnnotation": {
           "type": "TSTypeReference",
@@ -2505,7 +2505,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSIndexedAccessType",

--- a/test-typescript/tests/cases/conformance/types/mapped/mappedTypes6.ts.md
+++ b/test-typescript/tests/cases/conformance/types/mapped/mappedTypes6.ts.md
@@ -54,7 +54,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSIndexedAccessType",
@@ -510,7 +510,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": true,
         "typeAnnotation": {
           "type": "TSIndexedAccessType",
@@ -966,7 +966,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": "+",
         "typeAnnotation": {
           "type": "TSIndexedAccessType",
@@ -1422,7 +1422,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": "-",
         "typeAnnotation": {
           "type": "TSIndexedAccessType",
@@ -3509,7 +3509,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": "-",
         "typeAnnotation": {
           "type": "TSIndexedAccessType",

--- a/test-typescript/tests/cases/conformance/types/mapped/mappedTypesArraysTuples.ts.md
+++ b/test-typescript/tests/cases/conformance/types/mapped/mappedTypesArraysTuples.ts.md
@@ -141,7 +141,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSTypeReference",
@@ -1637,7 +1637,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": "-",
         "typeAnnotation": {
           "type": "TSIndexedAccessType",
@@ -3300,7 +3300,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSTypeReference",
@@ -4440,7 +4440,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSIndexedAccessType",

--- a/test-typescript/tests/cases/conformance/types/mapped/mappedTypesGenericTuples.ts.md
+++ b/test-typescript/tests/cases/conformance/types/mapped/mappedTypesGenericTuples.ts.md
@@ -54,7 +54,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSTypeReference",
@@ -148,7 +148,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSIndexedAccessType",
@@ -1421,7 +1421,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSTypeReference",

--- a/test-typescript/tests/cases/conformance/types/mapped/recursiveMappedTypes.ts.md
+++ b/test-typescript/tests/cases/conformance/types/mapped/recursiveMappedTypes.ts.md
@@ -54,7 +54,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSIndexedAccessType",
@@ -143,7 +143,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSIndexedAccessType",
@@ -232,7 +232,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSIndexedAccessType",
@@ -326,7 +326,7 @@ __ESTREE_TEST__:PASS:
             "typeAnnotation": null
           },
           "nameType": null,
-          "optional": null,
+          "optional": false,
           "readonly": null,
           "typeAnnotation": {
             "type": "TSTypeReference",
@@ -599,7 +599,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSConditionalType",
@@ -1039,7 +1039,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSTypeReference",
@@ -1466,7 +1466,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSTypeReference",
@@ -1640,7 +1640,7 @@ __ESTREE_TEST__:PASS:
             "typeAnnotation": null
           },
           "nameType": null,
-          "optional": null,
+          "optional": false,
           "readonly": null,
           "typeAnnotation": {
             "type": "TSTypeReference",
@@ -1895,7 +1895,7 @@ __ESTREE_TEST__:PASS:
             "typeAnnotation": null
           },
           "nameType": null,
-          "optional": null,
+          "optional": false,
           "readonly": null,
           "typeAnnotation": {
             "type": "TSConditionalType",
@@ -2055,7 +2055,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSIndexedAccessType",
@@ -3370,7 +3370,7 @@ __ESTREE_TEST__:PASS:
               "typeAnnotation": null
             },
             "nameType": null,
-            "optional": null,
+            "optional": false,
             "readonly": null,
             "typeAnnotation": {
               "type": "TSAnyKeyword",

--- a/test-typescript/tests/cases/conformance/types/members/indexSignatures1.ts.md
+++ b/test-typescript/tests/cases/conformance/types/members/indexSignatures1.ts.md
@@ -8270,7 +8270,7 @@ __ESTREE_TEST__:PASS:
                     "typeAnnotation": null
                   },
                   "nameType": null,
-                  "optional": null,
+                  "optional": false,
                   "readonly": null,
                   "typeAnnotation": {
                     "type": "TSFunctionType",
@@ -9373,7 +9373,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSStringKeyword",
@@ -9650,7 +9650,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSObjectKeyword",

--- a/test-typescript/tests/cases/conformance/types/nonPrimitive/nonPrimitiveAndTypeVariables.ts.md
+++ b/test-typescript/tests/cases/conformance/types/nonPrimitive/nonPrimitiveAndTypeVariables.ts.md
@@ -54,7 +54,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSConditionalType",
@@ -231,7 +231,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSConditionalType",

--- a/test-typescript/tests/cases/conformance/types/thisType/thisTypeInObjectLiterals2.ts.md
+++ b/test-typescript/tests/cases/conformance/types/thisType/thisTypeInObjectLiterals2.ts.md
@@ -4504,7 +4504,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSTypeReference",
@@ -6113,7 +6113,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSUnionType",

--- a/test-typescript/tests/cases/conformance/types/tuple/named/partiallyNamedTuples.ts.md
+++ b/test-typescript/tests/cases/conformance/types/tuple/named/partiallyNamedTuples.ts.md
@@ -611,7 +611,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSTupleType",
@@ -999,7 +999,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSTupleType",
@@ -1974,7 +1974,7 @@ __ESTREE_TEST__:PASS:
                       "typeAnnotation": null
                     },
                     "nameType": null,
-                    "optional": null,
+                    "optional": false,
                     "readonly": null,
                     "typeAnnotation": {
                       "type": "TSTypeLiteral",

--- a/test-typescript/tests/cases/conformance/types/tuple/variadicTuples1.ts.md
+++ b/test-typescript/tests/cases/conformance/types/tuple/variadicTuples1.ts.md
@@ -4929,7 +4929,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSArrayType",

--- a/test-typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/typeParameterConstModifiers.ts.md
+++ b/test-typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/typeParameterConstModifiers.ts.md
@@ -5513,7 +5513,7 @@ __ESTREE_TEST__:PASS:
             "typeAnnotation": null
           },
           "nameType": null,
-          "optional": null,
+          "optional": false,
           "readonly": null,
           "typeAnnotation": {
             "type": "TSIndexedAccessType",

--- a/test-typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/typeParameterConstModifiersReverseMappedTypes.ts.md
+++ b/test-typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/typeParameterConstModifiersReverseMappedTypes.ts.md
@@ -70,7 +70,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSIndexedAccessType",
@@ -372,7 +372,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": true,
               "typeAnnotation": {
                 "type": "TSIndexedAccessType",
@@ -674,7 +674,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": "-",
               "typeAnnotation": {
                 "type": "TSIndexedAccessType",
@@ -976,7 +976,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSIndexedAccessType",
@@ -1215,7 +1215,7 @@ __ESTREE_TEST__:PASS:
                 "typeAnnotation": null
               },
               "nameType": null,
-              "optional": null,
+              "optional": false,
               "readonly": null,
               "typeAnnotation": {
                 "type": "TSIndexedAccessType",

--- a/test-typescript/tests/cases/conformance/types/typeRelationships/typeInference/intraExpressionInferences.ts.md
+++ b/test-typescript/tests/cases/conformance/types/typeRelationships/typeInference/intraExpressionInferences.ts.md
@@ -3482,7 +3482,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSConditionalType",

--- a/test-typescript/tests/cases/conformance/types/typeRelationships/typeInference/keyofInferenceLowerPriorityThanReturn.ts.md
+++ b/test-typescript/tests/cases/conformance/types/typeRelationships/typeInference/keyofInferenceLowerPriorityThanReturn.ts.md
@@ -509,7 +509,7 @@ __ESTREE_TEST__:PASS:
               "typeAnnotation": null
             },
             "nameType": null,
-            "optional": null,
+            "optional": false,
             "readonly": null,
             "typeAnnotation": {
               "type": "TSTypeReference",
@@ -618,7 +618,7 @@ __ESTREE_TEST__:PASS:
               "typeAnnotation": null
             },
             "nameType": null,
-            "optional": null,
+            "optional": false,
             "readonly": null,
             "typeAnnotation": {
               "type": "TSTypeReference",

--- a/test-typescript/tests/cases/conformance/types/typeRelationships/typeInference/noInfer.ts.md
+++ b/test-typescript/tests/cases/conformance/types/typeRelationships/typeInference/noInfer.ts.md
@@ -1177,7 +1177,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSTypeReference",

--- a/test-typescript/tests/cases/conformance/types/typeRelationships/typeInference/unionTypeInference.ts.md
+++ b/test-typescript/tests/cases/conformance/types/typeRelationships/typeInference/unionTypeInference.ts.md
@@ -2741,7 +2741,7 @@ __ESTREE_TEST__:PASS:
               "typeAnnotation": null
             },
             "nameType": null,
-            "optional": null,
+            "optional": false,
             "readonly": null,
             "typeAnnotation": {
               "type": "TSUnionType",
@@ -3393,7 +3393,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSUnionType",

--- a/test-typescript/tests/cases/conformance/types/uniqueSymbol/uniqueSymbolsErrors.ts.md
+++ b/test-typescript/tests/cases/conformance/types/uniqueSymbol/uniqueSymbolsErrors.ts.md
@@ -3576,7 +3576,7 @@ __ESTREE_TEST__:PASS:
                   "typeAnnotation": null
                 },
                 "nameType": null,
-                "optional": null,
+                "optional": false,
                 "readonly": null,
                 "typeAnnotation": {
                   "type": "TSTypeOperator",

--- a/test-typescript/tests/cases/conformance/types/unknown/unknownType1.ts.md
+++ b/test-typescript/tests/cases/conformance/types/unknown/unknownType1.ts.md
@@ -2278,7 +2278,7 @@ __ESTREE_TEST__:PASS:
           "typeAnnotation": null
         },
         "nameType": null,
-        "optional": null,
+        "optional": false,
         "readonly": null,
         "typeAnnotation": {
           "type": "TSNumberKeyword",


### PR DESCRIPTION
Bump `@typescript-eslint/parser` dependency, and regenerate TS test fixtures.

Desirable mainly to include https://github.com/typescript-eslint/typescript-eslint/pull/11115, which will allow simplifying code on Oxc's side.
