### PR TITLE
feat: add `phase` field to `ImportExpression` in JS AST only

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ So in both cases, the `BigInt` / `RegExp` can be reconstructed from this extra d
 
 `Infinity` is serialized as `1e+400` - which `JSON.parse` converts back to `Infinity`.
 
-A `phase` field is added to `ImportDeclaration` (stage 3 proposal).
+A `phase` field is added to `ImportDeclaration` and `ImportExpression` (stage 3 proposal).
 
 A non-standard `hashbang` field is added to `Program`.
 

--- a/test/language/expressions/dynamic-import/always-create-new-promise.json
+++ b/test/language/expressions/dynamic-import/always-create-new-promise.json
@@ -29,7 +29,8 @@
               "value": "./dynamic-import-module_FIXTURE.js",
               "raw": "'./dynamic-import-module_FIXTURE.js'"
             },
-            "options": null
+            "options": null,
+            "phase": null
           }
         }
       ],
@@ -61,7 +62,8 @@
               "value": "./dynamic-import-module_FIXTURE.js",
               "raw": "'./dynamic-import-module_FIXTURE.js'"
             },
-            "options": null
+            "options": null,
+            "phase": null
           }
         }
       ],

--- a/test/language/expressions/dynamic-import/assign-expr-get-value-abrupt-throws.json
+++ b/test/language/expressions/dynamic-import/assign-expr-get-value-abrupt-throws.json
@@ -161,7 +161,8 @@
                       "computed": false,
                       "optional": false
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   }
                 }
               ]
@@ -240,7 +241,8 @@
                       "end": 1214,
                       "name": "refErr"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   }
                 }
               ]

--- a/test/language/expressions/dynamic-import/assignment-expression/additive-expr.json
+++ b/test/language/expressions/dynamic-import/assignment-expression/additive-expr.json
@@ -167,7 +167,8 @@
                         "name": "a"
                       }
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   }
                 }
               }
@@ -331,7 +332,8 @@
                         "name": "b"
                       }
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   }
                 }
               }

--- a/test/language/expressions/dynamic-import/assignment-expression/array-literal.json
+++ b/test/language/expressions/dynamic-import/assignment-expression/array-literal.json
@@ -110,7 +110,8 @@
                         }
                       ]
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   }
                 }
               }
@@ -321,7 +322,8 @@
                       "end": 1165,
                       "elements": []
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   }
                 }
               }

--- a/test/language/expressions/dynamic-import/assignment-expression/arrow-function.json
+++ b/test/language/expressions/dynamic-import/assignment-expression/arrow-function.json
@@ -121,7 +121,8 @@
                         "body": []
                       }
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   }
                 }
               }

--- a/test/language/expressions/dynamic-import/assignment-expression/await-expr.json
+++ b/test/language/expressions/dynamic-import/assignment-expression/await-expr.json
@@ -108,7 +108,8 @@
                         "name": "a"
                       }
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   }
                 }
               }
@@ -265,7 +266,8 @@
                         "name": "b"
                       }
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   }
                 }
               }

--- a/test/language/expressions/dynamic-import/assignment-expression/await-identifier.json
+++ b/test/language/expressions/dynamic-import/assignment-expression/await-identifier.json
@@ -63,7 +63,8 @@
                 "end": 923,
                 "name": "await"
               },
-              "options": null
+              "options": null,
+              "phase": null
             }
           }
         }

--- a/test/language/expressions/dynamic-import/assignment-expression/call-expr-arguments.json
+++ b/test/language/expressions/dynamic-import/assignment-expression/call-expr-arguments.json
@@ -157,7 +157,8 @@
                       "arguments": [],
                       "optional": false
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   }
                 }
               }
@@ -323,7 +324,8 @@
                       "arguments": [],
                       "optional": false
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   }
                 }
               }

--- a/test/language/expressions/dynamic-import/assignment-expression/call-expr-expr.json
+++ b/test/language/expressions/dynamic-import/assignment-expression/call-expr-expr.json
@@ -122,7 +122,8 @@
                       "computed": true,
                       "optional": false
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   }
                 }
               }
@@ -309,7 +310,8 @@
                       "computed": true,
                       "optional": false
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   }
                 }
               }

--- a/test/language/expressions/dynamic-import/assignment-expression/call-expr-identifier.json
+++ b/test/language/expressions/dynamic-import/assignment-expression/call-expr-identifier.json
@@ -156,7 +156,8 @@
                       "computed": false,
                       "optional": false
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   }
                 }
               }
@@ -328,7 +329,8 @@
                       "computed": false,
                       "optional": false
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   }
                 }
               }

--- a/test/language/expressions/dynamic-import/assignment-expression/cover-call-expr.json
+++ b/test/language/expressions/dynamic-import/assignment-expression/cover-call-expr.json
@@ -130,7 +130,8 @@
                       "arguments": [],
                       "optional": false
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   }
                 }
               }
@@ -289,7 +290,8 @@
                       "arguments": [],
                       "optional": false
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   }
                 }
               }

--- a/test/language/expressions/dynamic-import/assignment-expression/cover-parenthesized-expr.json
+++ b/test/language/expressions/dynamic-import/assignment-expression/cover-parenthesized-expr.json
@@ -82,7 +82,8 @@
                         }
                       }
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   }
                 }
               }
@@ -261,7 +262,8 @@
                         ]
                       }
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   }
                 }
               }

--- a/test/language/expressions/dynamic-import/assignment-expression/identifier.json
+++ b/test/language/expressions/dynamic-import/assignment-expression/identifier.json
@@ -103,7 +103,8 @@
                       "end": 962,
                       "name": "a"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   }
                 }
               }
@@ -255,7 +256,8 @@
                       "end": 1119,
                       "name": "b"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   }
                 }
               }

--- a/test/language/expressions/dynamic-import/assignment-expression/import-meta.json
+++ b/test/language/expressions/dynamic-import/assignment-expression/import-meta.json
@@ -39,7 +39,8 @@
                 "name": "meta"
               }
             },
-            "options": null
+            "options": null,
+            "phase": null
           }
         }
       ],

--- a/test/language/expressions/dynamic-import/assignment-expression/lhs-assign-operator-assign-expr.json
+++ b/test/language/expressions/dynamic-import/assignment-expression/lhs-assign-operator-assign-expr.json
@@ -167,7 +167,8 @@
                         "name": "a"
                       }
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   }
                 }
               }
@@ -331,7 +332,8 @@
                         "name": "b"
                       }
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   }
                 }
               }

--- a/test/language/expressions/dynamic-import/assignment-expression/lhs-eq-assign-expr-nostrict.json
+++ b/test/language/expressions/dynamic-import/assignment-expression/lhs-eq-assign-expr-nostrict.json
@@ -188,7 +188,8 @@
                         "name": "b"
                       }
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   }
                 }
               }

--- a/test/language/expressions/dynamic-import/assignment-expression/lhs-eq-assign-expr.json
+++ b/test/language/expressions/dynamic-import/assignment-expression/lhs-eq-assign-expr.json
@@ -189,7 +189,8 @@
                         "name": "a"
                       }
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   }
                 }
               }
@@ -366,7 +367,8 @@
                         "name": "b"
                       }
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   }
                 }
               }

--- a/test/language/expressions/dynamic-import/assignment-expression/logical-and-expr.json
+++ b/test/language/expressions/dynamic-import/assignment-expression/logical-and-expr.json
@@ -115,7 +115,8 @@
                         "name": "a"
                       }
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   }
                 }
               }
@@ -329,7 +330,8 @@
                         "name": "b"
                       }
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   }
                 }
               }

--- a/test/language/expressions/dynamic-import/assignment-expression/logical-or-expr.json
+++ b/test/language/expressions/dynamic-import/assignment-expression/logical-or-expr.json
@@ -115,7 +115,8 @@
                         "name": "b"
                       }
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   }
                 }
               }
@@ -280,7 +281,8 @@
                         "name": "b"
                       }
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   }
                 }
               }

--- a/test/language/expressions/dynamic-import/assignment-expression/member-expr.json
+++ b/test/language/expressions/dynamic-import/assignment-expression/member-expr.json
@@ -135,7 +135,8 @@
                       "computed": true,
                       "optional": false
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   }
                 }
               }
@@ -300,7 +301,8 @@
                       "computed": false,
                       "optional": false
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   }
                 }
               }

--- a/test/language/expressions/dynamic-import/assignment-expression/new-target.json
+++ b/test/language/expressions/dynamic-import/assignment-expression/new-target.json
@@ -47,7 +47,8 @@
                   "name": "target"
                 }
               },
-              "options": null
+              "options": null,
+              "phase": null
             }
           }
         ]

--- a/test/language/expressions/dynamic-import/assignment-expression/object-literal.json
+++ b/test/language/expressions/dynamic-import/assignment-expression/object-literal.json
@@ -147,7 +147,8 @@
                         }
                       ]
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   }
                 }
               }
@@ -358,7 +359,8 @@
                       "end": 1192,
                       "properties": []
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   }
                 }
               }

--- a/test/language/expressions/dynamic-import/assignment-expression/tagged-function-call.json
+++ b/test/language/expressions/dynamic-import/assignment-expression/tagged-function-call.json
@@ -128,7 +128,8 @@
                         ]
                       }
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   }
                 }
               }

--- a/test/language/expressions/dynamic-import/assignment-expression/ternary.json
+++ b/test/language/expressions/dynamic-import/assignment-expression/ternary.json
@@ -121,7 +121,8 @@
                         "name": "b"
                       }
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   }
                 }
               }
@@ -291,7 +292,8 @@
                         "name": "b"
                       }
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   }
                 }
               }

--- a/test/language/expressions/dynamic-import/assignment-expression/this.json
+++ b/test/language/expressions/dynamic-import/assignment-expression/this.json
@@ -50,7 +50,8 @@
                       "start": 895,
                       "end": 899
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   }
                 }
               }

--- a/test/language/expressions/dynamic-import/assignment-expression/unary-expr.json
+++ b/test/language/expressions/dynamic-import/assignment-expression/unary-expr.json
@@ -85,7 +85,8 @@
             "optional": false
           }
         },
-        "options": null
+        "options": null,
+        "phase": null
       }
     },
     {
@@ -110,7 +111,8 @@
             "raw": "0"
           }
         },
-        "options": null
+        "options": null,
+        "phase": null
       }
     },
     {
@@ -134,7 +136,8 @@
             "properties": []
           }
         },
-        "options": null
+        "options": null,
+        "phase": null
       }
     },
     {
@@ -166,7 +169,8 @@
             }
           }
         },
-        "options": null
+        "options": null,
+        "phase": null
       }
     },
     {
@@ -198,7 +202,8 @@
             }
           }
         },
-        "options": null
+        "options": null,
+        "phase": null
       }
     },
     {
@@ -230,7 +235,8 @@
             }
           }
         },
-        "options": null
+        "options": null,
+        "phase": null
       }
     },
     {
@@ -262,7 +268,8 @@
             }
           }
         },
-        "options": null
+        "options": null,
+        "phase": null
       }
     },
     {
@@ -329,7 +336,8 @@
             }
           }
         },
-        "options": null
+        "options": null,
+        "phase": null
       }
     }
   ],

--- a/test/language/expressions/dynamic-import/assignment-expression/yield-assign-expr.json
+++ b/test/language/expressions/dynamic-import/assignment-expression/yield-assign-expr.json
@@ -95,7 +95,8 @@
                   "raw": "42"
                 }
               },
-              "options": null
+              "options": null,
+              "phase": null
             }
           }
         ]

--- a/test/language/expressions/dynamic-import/assignment-expression/yield-expr.json
+++ b/test/language/expressions/dynamic-import/assignment-expression/yield-expr.json
@@ -89,7 +89,8 @@
                 "delegate": false,
                 "argument": null
               },
-              "options": null
+              "options": null,
+              "phase": null
             }
           }
         ]

--- a/test/language/expressions/dynamic-import/assignment-expression/yield-identifier.json
+++ b/test/language/expressions/dynamic-import/assignment-expression/yield-identifier.json
@@ -77,7 +77,8 @@
                       "end": 952,
                       "name": "yield"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   }
                 }
               }

--- a/test/language/expressions/dynamic-import/assignment-expression/yield-star.json
+++ b/test/language/expressions/dynamic-import/assignment-expression/yield-star.json
@@ -64,7 +64,8 @@
                   ]
                 }
               },
-              "options": null
+              "options": null,
+              "phase": null
             }
           }
         ]

--- a/test/language/expressions/dynamic-import/await-import-evaluation.json
+++ b/test/language/expressions/dynamic-import/await-import-evaluation.json
@@ -79,7 +79,8 @@
                   "value": "./await-import-evaluation_FIXTURE.js",
                   "raw": "'./await-import-evaluation_FIXTURE.js'"
                 },
-                "options": null
+                "options": null,
+                "phase": null
               },
               "property": {
                 "type": "Identifier",

--- a/test/language/expressions/dynamic-import/catch/nested-arrow-import-catch-eval-rqstd-abrupt-typeerror.json
+++ b/test/language/expressions/dynamic-import/catch/nested-arrow-import-catch-eval-rqstd-abrupt-typeerror.json
@@ -63,7 +63,8 @@
                               "value": "./eval-rqstd-abrupt-err-type_FIXTURE.js",
                               "raw": "'./eval-rqstd-abrupt-err-type_FIXTURE.js'"
                             },
-                            "options": null
+                            "options": null,
+                            "phase": null
                           },
                           "property": {
                             "type": "Identifier",

--- a/test/language/expressions/dynamic-import/catch/nested-arrow-import-catch-eval-rqstd-abrupt-urierror.json
+++ b/test/language/expressions/dynamic-import/catch/nested-arrow-import-catch-eval-rqstd-abrupt-urierror.json
@@ -63,7 +63,8 @@
                               "value": "./eval-rqstd-abrupt-err-uri_FIXTURE.js",
                               "raw": "'./eval-rqstd-abrupt-err-uri_FIXTURE.js'"
                             },
-                            "options": null
+                            "options": null,
+                            "phase": null
                           },
                           "property": {
                             "type": "Identifier",

--- a/test/language/expressions/dynamic-import/catch/nested-arrow-import-catch-eval-script-code-target.json
+++ b/test/language/expressions/dynamic-import/catch/nested-arrow-import-catch-eval-script-code-target.json
@@ -63,7 +63,8 @@
                               "value": "./script-code_FIXTURE.js",
                               "raw": "'./script-code_FIXTURE.js'"
                             },
-                            "options": null
+                            "options": null,
+                            "phase": null
                           },
                           "property": {
                             "type": "Identifier",

--- a/test/language/expressions/dynamic-import/catch/nested-arrow-import-catch-file-does-not-exist.json
+++ b/test/language/expressions/dynamic-import/catch/nested-arrow-import-catch-file-does-not-exist.json
@@ -63,7 +63,8 @@
                               "value": "./THIS_FILE_DOES_NOT_EXIST.js",
                               "raw": "'./THIS_FILE_DOES_NOT_EXIST.js'"
                             },
-                            "options": null
+                            "options": null,
+                            "phase": null
                           },
                           "property": {
                             "type": "Identifier",

--- a/test/language/expressions/dynamic-import/catch/nested-arrow-import-catch-instn-iee-err-ambiguous-import.json
+++ b/test/language/expressions/dynamic-import/catch/nested-arrow-import-catch-instn-iee-err-ambiguous-import.json
@@ -63,7 +63,8 @@
                               "value": "./instn-iee-err-ambiguous-export_FIXTURE.js",
                               "raw": "'./instn-iee-err-ambiguous-export_FIXTURE.js'"
                             },
-                            "options": null
+                            "options": null,
+                            "phase": null
                           },
                           "property": {
                             "type": "Identifier",

--- a/test/language/expressions/dynamic-import/catch/nested-arrow-import-catch-instn-iee-err-circular.json
+++ b/test/language/expressions/dynamic-import/catch/nested-arrow-import-catch-instn-iee-err-circular.json
@@ -63,7 +63,8 @@
                               "value": "./instn-iee-err-circular-1_FIXTURE.js",
                               "raw": "'./instn-iee-err-circular-1_FIXTURE.js'"
                             },
-                            "options": null
+                            "options": null,
+                            "phase": null
                           },
                           "property": {
                             "type": "Identifier",

--- a/test/language/expressions/dynamic-import/catch/nested-arrow-import-catch-specifier-tostring-abrupt-rejects.json
+++ b/test/language/expressions/dynamic-import/catch/nested-arrow-import-catch-specifier-tostring-abrupt-rejects.json
@@ -132,7 +132,8 @@
                               "end": 1782,
                               "name": "obj"
                             },
-                            "options": null
+                            "options": null,
+                            "phase": null
                           },
                           "property": {
                             "type": "Identifier",

--- a/test/language/expressions/dynamic-import/catch/nested-async-arrow-function-await-eval-rqstd-abrupt-typeerror.json
+++ b/test/language/expressions/dynamic-import/catch/nested-async-arrow-function-await-eval-rqstd-abrupt-typeerror.json
@@ -51,7 +51,8 @@
                         "value": "./eval-rqstd-abrupt-err-type_FIXTURE.js",
                         "raw": "'./eval-rqstd-abrupt-err-type_FIXTURE.js'"
                       },
-                      "options": null
+                      "options": null,
+                      "phase": null
                     }
                   }
                 }

--- a/test/language/expressions/dynamic-import/catch/nested-async-arrow-function-await-eval-rqstd-abrupt-urierror.json
+++ b/test/language/expressions/dynamic-import/catch/nested-async-arrow-function-await-eval-rqstd-abrupt-urierror.json
@@ -51,7 +51,8 @@
                         "value": "./eval-rqstd-abrupt-err-uri_FIXTURE.js",
                         "raw": "'./eval-rqstd-abrupt-err-uri_FIXTURE.js'"
                       },
-                      "options": null
+                      "options": null,
+                      "phase": null
                     }
                   }
                 }

--- a/test/language/expressions/dynamic-import/catch/nested-async-arrow-function-await-eval-script-code-target.json
+++ b/test/language/expressions/dynamic-import/catch/nested-async-arrow-function-await-eval-script-code-target.json
@@ -51,7 +51,8 @@
                         "value": "./script-code_FIXTURE.js",
                         "raw": "'./script-code_FIXTURE.js'"
                       },
-                      "options": null
+                      "options": null,
+                      "phase": null
                     }
                   }
                 }

--- a/test/language/expressions/dynamic-import/catch/nested-async-arrow-function-await-file-does-not-exist.json
+++ b/test/language/expressions/dynamic-import/catch/nested-async-arrow-function-await-file-does-not-exist.json
@@ -51,7 +51,8 @@
                         "value": "./THIS_FILE_DOES_NOT_EXIST.js",
                         "raw": "'./THIS_FILE_DOES_NOT_EXIST.js'"
                       },
-                      "options": null
+                      "options": null,
+                      "phase": null
                     }
                   }
                 }

--- a/test/language/expressions/dynamic-import/catch/nested-async-arrow-function-await-instn-iee-err-ambiguous-import.json
+++ b/test/language/expressions/dynamic-import/catch/nested-async-arrow-function-await-instn-iee-err-ambiguous-import.json
@@ -51,7 +51,8 @@
                         "value": "./instn-iee-err-ambiguous-export_FIXTURE.js",
                         "raw": "'./instn-iee-err-ambiguous-export_FIXTURE.js'"
                       },
-                      "options": null
+                      "options": null,
+                      "phase": null
                     }
                   }
                 }

--- a/test/language/expressions/dynamic-import/catch/nested-async-arrow-function-await-instn-iee-err-circular.json
+++ b/test/language/expressions/dynamic-import/catch/nested-async-arrow-function-await-instn-iee-err-circular.json
@@ -51,7 +51,8 @@
                         "value": "./instn-iee-err-circular-1_FIXTURE.js",
                         "raw": "'./instn-iee-err-circular-1_FIXTURE.js'"
                       },
-                      "options": null
+                      "options": null,
+                      "phase": null
                     }
                   }
                 }

--- a/test/language/expressions/dynamic-import/catch/nested-async-arrow-function-await-specifier-tostring-abrupt-rejects.json
+++ b/test/language/expressions/dynamic-import/catch/nested-async-arrow-function-await-specifier-tostring-abrupt-rejects.json
@@ -120,7 +120,8 @@
                         "end": 1838,
                         "name": "obj"
                       },
-                      "options": null
+                      "options": null,
+                      "phase": null
                     }
                   }
                 }

--- a/test/language/expressions/dynamic-import/catch/nested-async-arrow-function-return-await-eval-rqstd-abrupt-typeerror.json
+++ b/test/language/expressions/dynamic-import/catch/nested-async-arrow-function-return-await-eval-rqstd-abrupt-typeerror.json
@@ -42,7 +42,8 @@
                   "value": "./eval-rqstd-abrupt-err-type_FIXTURE.js",
                   "raw": "'./eval-rqstd-abrupt-err-type_FIXTURE.js'"
                 },
-                "options": null
+                "options": null,
+                "phase": null
               }
             }
           }

--- a/test/language/expressions/dynamic-import/catch/nested-async-arrow-function-return-await-eval-rqstd-abrupt-urierror.json
+++ b/test/language/expressions/dynamic-import/catch/nested-async-arrow-function-return-await-eval-rqstd-abrupt-urierror.json
@@ -42,7 +42,8 @@
                   "value": "./eval-rqstd-abrupt-err-uri_FIXTURE.js",
                   "raw": "'./eval-rqstd-abrupt-err-uri_FIXTURE.js'"
                 },
-                "options": null
+                "options": null,
+                "phase": null
               }
             }
           }

--- a/test/language/expressions/dynamic-import/catch/nested-async-arrow-function-return-await-eval-script-code-target.json
+++ b/test/language/expressions/dynamic-import/catch/nested-async-arrow-function-return-await-eval-script-code-target.json
@@ -42,7 +42,8 @@
                   "value": "./script-code_FIXTURE.js",
                   "raw": "'./script-code_FIXTURE.js'"
                 },
-                "options": null
+                "options": null,
+                "phase": null
               }
             }
           }

--- a/test/language/expressions/dynamic-import/catch/nested-async-arrow-function-return-await-file-does-not-exist.json
+++ b/test/language/expressions/dynamic-import/catch/nested-async-arrow-function-return-await-file-does-not-exist.json
@@ -42,7 +42,8 @@
                   "value": "./THIS_FILE_DOES_NOT_EXIST.js",
                   "raw": "'./THIS_FILE_DOES_NOT_EXIST.js'"
                 },
-                "options": null
+                "options": null,
+                "phase": null
               }
             }
           }

--- a/test/language/expressions/dynamic-import/catch/nested-async-arrow-function-return-await-instn-iee-err-ambiguous-import.json
+++ b/test/language/expressions/dynamic-import/catch/nested-async-arrow-function-return-await-instn-iee-err-ambiguous-import.json
@@ -42,7 +42,8 @@
                   "value": "./instn-iee-err-ambiguous-export_FIXTURE.js",
                   "raw": "'./instn-iee-err-ambiguous-export_FIXTURE.js'"
                 },
-                "options": null
+                "options": null,
+                "phase": null
               }
             }
           }

--- a/test/language/expressions/dynamic-import/catch/nested-async-arrow-function-return-await-instn-iee-err-circular.json
+++ b/test/language/expressions/dynamic-import/catch/nested-async-arrow-function-return-await-instn-iee-err-circular.json
@@ -42,7 +42,8 @@
                   "value": "./instn-iee-err-circular-1_FIXTURE.js",
                   "raw": "'./instn-iee-err-circular-1_FIXTURE.js'"
                 },
-                "options": null
+                "options": null,
+                "phase": null
               }
             }
           }

--- a/test/language/expressions/dynamic-import/catch/nested-async-arrow-function-return-await-specifier-tostring-abrupt-rejects.json
+++ b/test/language/expressions/dynamic-import/catch/nested-async-arrow-function-return-await-specifier-tostring-abrupt-rejects.json
@@ -111,7 +111,8 @@
                   "end": 1842,
                   "name": "obj"
                 },
-                "options": null
+                "options": null,
+                "phase": null
               }
             }
           }

--- a/test/language/expressions/dynamic-import/catch/nested-async-function-await-eval-rqstd-abrupt-typeerror.json
+++ b/test/language/expressions/dynamic-import/catch/nested-async-function-await-eval-rqstd-abrupt-typeerror.json
@@ -57,7 +57,8 @@
                           "value": "./eval-rqstd-abrupt-err-type_FIXTURE.js",
                           "raw": "'./eval-rqstd-abrupt-err-type_FIXTURE.js'"
                         },
-                        "options": null
+                        "options": null,
+                        "phase": null
                       },
                       "property": {
                         "type": "Identifier",

--- a/test/language/expressions/dynamic-import/catch/nested-async-function-await-eval-rqstd-abrupt-urierror.json
+++ b/test/language/expressions/dynamic-import/catch/nested-async-function-await-eval-rqstd-abrupt-urierror.json
@@ -57,7 +57,8 @@
                           "value": "./eval-rqstd-abrupt-err-uri_FIXTURE.js",
                           "raw": "'./eval-rqstd-abrupt-err-uri_FIXTURE.js'"
                         },
-                        "options": null
+                        "options": null,
+                        "phase": null
                       },
                       "property": {
                         "type": "Identifier",

--- a/test/language/expressions/dynamic-import/catch/nested-async-function-await-eval-script-code-target.json
+++ b/test/language/expressions/dynamic-import/catch/nested-async-function-await-eval-script-code-target.json
@@ -57,7 +57,8 @@
                           "value": "./script-code_FIXTURE.js",
                           "raw": "'./script-code_FIXTURE.js'"
                         },
-                        "options": null
+                        "options": null,
+                        "phase": null
                       },
                       "property": {
                         "type": "Identifier",

--- a/test/language/expressions/dynamic-import/catch/nested-async-function-await-file-does-not-exist.json
+++ b/test/language/expressions/dynamic-import/catch/nested-async-function-await-file-does-not-exist.json
@@ -57,7 +57,8 @@
                           "value": "./THIS_FILE_DOES_NOT_EXIST.js",
                           "raw": "'./THIS_FILE_DOES_NOT_EXIST.js'"
                         },
-                        "options": null
+                        "options": null,
+                        "phase": null
                       },
                       "property": {
                         "type": "Identifier",

--- a/test/language/expressions/dynamic-import/catch/nested-async-function-await-instn-iee-err-ambiguous-import.json
+++ b/test/language/expressions/dynamic-import/catch/nested-async-function-await-instn-iee-err-ambiguous-import.json
@@ -57,7 +57,8 @@
                           "value": "./instn-iee-err-ambiguous-export_FIXTURE.js",
                           "raw": "'./instn-iee-err-ambiguous-export_FIXTURE.js'"
                         },
-                        "options": null
+                        "options": null,
+                        "phase": null
                       },
                       "property": {
                         "type": "Identifier",

--- a/test/language/expressions/dynamic-import/catch/nested-async-function-await-instn-iee-err-circular.json
+++ b/test/language/expressions/dynamic-import/catch/nested-async-function-await-instn-iee-err-circular.json
@@ -57,7 +57,8 @@
                           "value": "./instn-iee-err-circular-1_FIXTURE.js",
                           "raw": "'./instn-iee-err-circular-1_FIXTURE.js'"
                         },
-                        "options": null
+                        "options": null,
+                        "phase": null
                       },
                       "property": {
                         "type": "Identifier",

--- a/test/language/expressions/dynamic-import/catch/nested-async-function-await-specifier-tostring-abrupt-rejects.json
+++ b/test/language/expressions/dynamic-import/catch/nested-async-function-await-specifier-tostring-abrupt-rejects.json
@@ -126,7 +126,8 @@
                           "end": 1829,
                           "name": "obj"
                         },
-                        "options": null
+                        "options": null,
+                        "phase": null
                       },
                       "property": {
                         "type": "Identifier",

--- a/test/language/expressions/dynamic-import/catch/nested-async-function-eval-rqstd-abrupt-typeerror.json
+++ b/test/language/expressions/dynamic-import/catch/nested-async-function-eval-rqstd-abrupt-typeerror.json
@@ -53,7 +53,8 @@
                         "value": "./eval-rqstd-abrupt-err-type_FIXTURE.js",
                         "raw": "'./eval-rqstd-abrupt-err-type_FIXTURE.js'"
                       },
-                      "options": null
+                      "options": null,
+                      "phase": null
                     },
                     "property": {
                       "type": "Identifier",

--- a/test/language/expressions/dynamic-import/catch/nested-async-function-eval-rqstd-abrupt-urierror.json
+++ b/test/language/expressions/dynamic-import/catch/nested-async-function-eval-rqstd-abrupt-urierror.json
@@ -53,7 +53,8 @@
                         "value": "./eval-rqstd-abrupt-err-uri_FIXTURE.js",
                         "raw": "'./eval-rqstd-abrupt-err-uri_FIXTURE.js'"
                       },
-                      "options": null
+                      "options": null,
+                      "phase": null
                     },
                     "property": {
                       "type": "Identifier",

--- a/test/language/expressions/dynamic-import/catch/nested-async-function-eval-script-code-target.json
+++ b/test/language/expressions/dynamic-import/catch/nested-async-function-eval-script-code-target.json
@@ -53,7 +53,8 @@
                         "value": "./script-code_FIXTURE.js",
                         "raw": "'./script-code_FIXTURE.js'"
                       },
-                      "options": null
+                      "options": null,
+                      "phase": null
                     },
                     "property": {
                       "type": "Identifier",

--- a/test/language/expressions/dynamic-import/catch/nested-async-function-file-does-not-exist.json
+++ b/test/language/expressions/dynamic-import/catch/nested-async-function-file-does-not-exist.json
@@ -53,7 +53,8 @@
                         "value": "./THIS_FILE_DOES_NOT_EXIST.js",
                         "raw": "'./THIS_FILE_DOES_NOT_EXIST.js'"
                       },
-                      "options": null
+                      "options": null,
+                      "phase": null
                     },
                     "property": {
                       "type": "Identifier",

--- a/test/language/expressions/dynamic-import/catch/nested-async-function-instn-iee-err-ambiguous-import.json
+++ b/test/language/expressions/dynamic-import/catch/nested-async-function-instn-iee-err-ambiguous-import.json
@@ -53,7 +53,8 @@
                         "value": "./instn-iee-err-ambiguous-export_FIXTURE.js",
                         "raw": "'./instn-iee-err-ambiguous-export_FIXTURE.js'"
                       },
-                      "options": null
+                      "options": null,
+                      "phase": null
                     },
                     "property": {
                       "type": "Identifier",

--- a/test/language/expressions/dynamic-import/catch/nested-async-function-instn-iee-err-circular.json
+++ b/test/language/expressions/dynamic-import/catch/nested-async-function-instn-iee-err-circular.json
@@ -53,7 +53,8 @@
                         "value": "./instn-iee-err-circular-1_FIXTURE.js",
                         "raw": "'./instn-iee-err-circular-1_FIXTURE.js'"
                       },
-                      "options": null
+                      "options": null,
+                      "phase": null
                     },
                     "property": {
                       "type": "Identifier",

--- a/test/language/expressions/dynamic-import/catch/nested-async-function-return-await-eval-rqstd-abrupt-typeerror.json
+++ b/test/language/expressions/dynamic-import/catch/nested-async-function-return-await-eval-rqstd-abrupt-typeerror.json
@@ -57,7 +57,8 @@
                           "value": "./eval-rqstd-abrupt-err-type_FIXTURE.js",
                           "raw": "'./eval-rqstd-abrupt-err-type_FIXTURE.js'"
                         },
-                        "options": null
+                        "options": null,
+                        "phase": null
                       },
                       "property": {
                         "type": "Identifier",

--- a/test/language/expressions/dynamic-import/catch/nested-async-function-return-await-eval-rqstd-abrupt-urierror.json
+++ b/test/language/expressions/dynamic-import/catch/nested-async-function-return-await-eval-rqstd-abrupt-urierror.json
@@ -57,7 +57,8 @@
                           "value": "./eval-rqstd-abrupt-err-uri_FIXTURE.js",
                           "raw": "'./eval-rqstd-abrupt-err-uri_FIXTURE.js'"
                         },
-                        "options": null
+                        "options": null,
+                        "phase": null
                       },
                       "property": {
                         "type": "Identifier",

--- a/test/language/expressions/dynamic-import/catch/nested-async-function-return-await-eval-script-code-target.json
+++ b/test/language/expressions/dynamic-import/catch/nested-async-function-return-await-eval-script-code-target.json
@@ -57,7 +57,8 @@
                           "value": "./script-code_FIXTURE.js",
                           "raw": "'./script-code_FIXTURE.js'"
                         },
-                        "options": null
+                        "options": null,
+                        "phase": null
                       },
                       "property": {
                         "type": "Identifier",

--- a/test/language/expressions/dynamic-import/catch/nested-async-function-return-await-file-does-not-exist.json
+++ b/test/language/expressions/dynamic-import/catch/nested-async-function-return-await-file-does-not-exist.json
@@ -57,7 +57,8 @@
                           "value": "./THIS_FILE_DOES_NOT_EXIST.js",
                           "raw": "'./THIS_FILE_DOES_NOT_EXIST.js'"
                         },
-                        "options": null
+                        "options": null,
+                        "phase": null
                       },
                       "property": {
                         "type": "Identifier",

--- a/test/language/expressions/dynamic-import/catch/nested-async-function-return-await-instn-iee-err-ambiguous-import.json
+++ b/test/language/expressions/dynamic-import/catch/nested-async-function-return-await-instn-iee-err-ambiguous-import.json
@@ -57,7 +57,8 @@
                           "value": "./instn-iee-err-ambiguous-export_FIXTURE.js",
                           "raw": "'./instn-iee-err-ambiguous-export_FIXTURE.js'"
                         },
-                        "options": null
+                        "options": null,
+                        "phase": null
                       },
                       "property": {
                         "type": "Identifier",

--- a/test/language/expressions/dynamic-import/catch/nested-async-function-return-await-instn-iee-err-circular.json
+++ b/test/language/expressions/dynamic-import/catch/nested-async-function-return-await-instn-iee-err-circular.json
@@ -57,7 +57,8 @@
                           "value": "./instn-iee-err-circular-1_FIXTURE.js",
                           "raw": "'./instn-iee-err-circular-1_FIXTURE.js'"
                         },
-                        "options": null
+                        "options": null,
+                        "phase": null
                       },
                       "property": {
                         "type": "Identifier",

--- a/test/language/expressions/dynamic-import/catch/nested-async-function-return-await-specifier-tostring-abrupt-rejects.json
+++ b/test/language/expressions/dynamic-import/catch/nested-async-function-return-await-specifier-tostring-abrupt-rejects.json
@@ -126,7 +126,8 @@
                           "end": 1851,
                           "name": "obj"
                         },
-                        "options": null
+                        "options": null,
+                        "phase": null
                       },
                       "property": {
                         "type": "Identifier",

--- a/test/language/expressions/dynamic-import/catch/nested-async-function-specifier-tostring-abrupt-rejects.json
+++ b/test/language/expressions/dynamic-import/catch/nested-async-function-specifier-tostring-abrupt-rejects.json
@@ -122,7 +122,8 @@
                         "end": 1808,
                         "name": "obj"
                       },
-                      "options": null
+                      "options": null,
+                      "phase": null
                     },
                     "property": {
                       "type": "Identifier",

--- a/test/language/expressions/dynamic-import/catch/nested-async-gen-await-eval-rqstd-abrupt-typeerror.json
+++ b/test/language/expressions/dynamic-import/catch/nested-async-gen-await-eval-rqstd-abrupt-typeerror.json
@@ -41,7 +41,8 @@
                   "value": "./eval-rqstd-abrupt-err-type_FIXTURE.js",
                   "raw": "'./eval-rqstd-abrupt-err-type_FIXTURE.js'"
                 },
-                "options": null
+                "options": null,
+                "phase": null
               }
             }
           }

--- a/test/language/expressions/dynamic-import/catch/nested-async-gen-await-eval-rqstd-abrupt-urierror.json
+++ b/test/language/expressions/dynamic-import/catch/nested-async-gen-await-eval-rqstd-abrupt-urierror.json
@@ -41,7 +41,8 @@
                   "value": "./eval-rqstd-abrupt-err-uri_FIXTURE.js",
                   "raw": "'./eval-rqstd-abrupt-err-uri_FIXTURE.js'"
                 },
-                "options": null
+                "options": null,
+                "phase": null
               }
             }
           }

--- a/test/language/expressions/dynamic-import/catch/nested-async-gen-await-eval-script-code-target.json
+++ b/test/language/expressions/dynamic-import/catch/nested-async-gen-await-eval-script-code-target.json
@@ -41,7 +41,8 @@
                   "value": "./script-code_FIXTURE.js",
                   "raw": "'./script-code_FIXTURE.js'"
                 },
-                "options": null
+                "options": null,
+                "phase": null
               }
             }
           }

--- a/test/language/expressions/dynamic-import/catch/nested-async-gen-await-file-does-not-exist.json
+++ b/test/language/expressions/dynamic-import/catch/nested-async-gen-await-file-does-not-exist.json
@@ -41,7 +41,8 @@
                   "value": "./THIS_FILE_DOES_NOT_EXIST.js",
                   "raw": "'./THIS_FILE_DOES_NOT_EXIST.js'"
                 },
-                "options": null
+                "options": null,
+                "phase": null
               }
             }
           }

--- a/test/language/expressions/dynamic-import/catch/nested-async-gen-await-instn-iee-err-ambiguous-import.json
+++ b/test/language/expressions/dynamic-import/catch/nested-async-gen-await-instn-iee-err-ambiguous-import.json
@@ -41,7 +41,8 @@
                   "value": "./instn-iee-err-ambiguous-export_FIXTURE.js",
                   "raw": "'./instn-iee-err-ambiguous-export_FIXTURE.js'"
                 },
-                "options": null
+                "options": null,
+                "phase": null
               }
             }
           }

--- a/test/language/expressions/dynamic-import/catch/nested-async-gen-await-instn-iee-err-circular.json
+++ b/test/language/expressions/dynamic-import/catch/nested-async-gen-await-instn-iee-err-circular.json
@@ -41,7 +41,8 @@
                   "value": "./instn-iee-err-circular-1_FIXTURE.js",
                   "raw": "'./instn-iee-err-circular-1_FIXTURE.js'"
                 },
-                "options": null
+                "options": null,
+                "phase": null
               }
             }
           }

--- a/test/language/expressions/dynamic-import/catch/nested-async-gen-await-specifier-tostring-abrupt-rejects.json
+++ b/test/language/expressions/dynamic-import/catch/nested-async-gen-await-specifier-tostring-abrupt-rejects.json
@@ -110,7 +110,8 @@
                   "end": 1850,
                   "name": "obj"
                 },
-                "options": null
+                "options": null,
+                "phase": null
               }
             }
           }

--- a/test/language/expressions/dynamic-import/catch/nested-async-gen-return-await-eval-rqstd-abrupt-typeerror.json
+++ b/test/language/expressions/dynamic-import/catch/nested-async-gen-return-await-eval-rqstd-abrupt-typeerror.json
@@ -41,7 +41,8 @@
                   "value": "./eval-rqstd-abrupt-err-type_FIXTURE.js",
                   "raw": "'./eval-rqstd-abrupt-err-type_FIXTURE.js'"
                 },
-                "options": null
+                "options": null,
+                "phase": null
               }
             }
           }

--- a/test/language/expressions/dynamic-import/catch/nested-async-gen-return-await-eval-rqstd-abrupt-urierror.json
+++ b/test/language/expressions/dynamic-import/catch/nested-async-gen-return-await-eval-rqstd-abrupt-urierror.json
@@ -41,7 +41,8 @@
                   "value": "./eval-rqstd-abrupt-err-uri_FIXTURE.js",
                   "raw": "'./eval-rqstd-abrupt-err-uri_FIXTURE.js'"
                 },
-                "options": null
+                "options": null,
+                "phase": null
               }
             }
           }

--- a/test/language/expressions/dynamic-import/catch/nested-async-gen-return-await-eval-script-code-target.json
+++ b/test/language/expressions/dynamic-import/catch/nested-async-gen-return-await-eval-script-code-target.json
@@ -41,7 +41,8 @@
                   "value": "./script-code_FIXTURE.js",
                   "raw": "'./script-code_FIXTURE.js'"
                 },
-                "options": null
+                "options": null,
+                "phase": null
               }
             }
           }

--- a/test/language/expressions/dynamic-import/catch/nested-async-gen-return-await-file-does-not-exist.json
+++ b/test/language/expressions/dynamic-import/catch/nested-async-gen-return-await-file-does-not-exist.json
@@ -41,7 +41,8 @@
                   "value": "./THIS_FILE_DOES_NOT_EXIST.js",
                   "raw": "'./THIS_FILE_DOES_NOT_EXIST.js'"
                 },
-                "options": null
+                "options": null,
+                "phase": null
               }
             }
           }

--- a/test/language/expressions/dynamic-import/catch/nested-async-gen-return-await-instn-iee-err-ambiguous-import.json
+++ b/test/language/expressions/dynamic-import/catch/nested-async-gen-return-await-instn-iee-err-ambiguous-import.json
@@ -41,7 +41,8 @@
                   "value": "./instn-iee-err-ambiguous-export_FIXTURE.js",
                   "raw": "'./instn-iee-err-ambiguous-export_FIXTURE.js'"
                 },
-                "options": null
+                "options": null,
+                "phase": null
               }
             }
           }

--- a/test/language/expressions/dynamic-import/catch/nested-async-gen-return-await-instn-iee-err-circular.json
+++ b/test/language/expressions/dynamic-import/catch/nested-async-gen-return-await-instn-iee-err-circular.json
@@ -41,7 +41,8 @@
                   "value": "./instn-iee-err-circular-1_FIXTURE.js",
                   "raw": "'./instn-iee-err-circular-1_FIXTURE.js'"
                 },
-                "options": null
+                "options": null,
+                "phase": null
               }
             }
           }

--- a/test/language/expressions/dynamic-import/catch/nested-async-gen-return-await-specifier-tostring-abrupt-rejects.json
+++ b/test/language/expressions/dynamic-import/catch/nested-async-gen-return-await-specifier-tostring-abrupt-rejects.json
@@ -110,7 +110,8 @@
                   "end": 1872,
                   "name": "obj"
                 },
-                "options": null
+                "options": null,
+                "phase": null
               }
             }
           }

--- a/test/language/expressions/dynamic-import/catch/nested-block-import-catch-eval-rqstd-abrupt-typeerror.json
+++ b/test/language/expressions/dynamic-import/catch/nested-block-import-catch-eval-rqstd-abrupt-typeerror.json
@@ -39,7 +39,8 @@
                       "value": "./eval-rqstd-abrupt-err-type_FIXTURE.js",
                       "raw": "'./eval-rqstd-abrupt-err-type_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   },
                   "property": {
                     "type": "Identifier",

--- a/test/language/expressions/dynamic-import/catch/nested-block-import-catch-eval-rqstd-abrupt-urierror.json
+++ b/test/language/expressions/dynamic-import/catch/nested-block-import-catch-eval-rqstd-abrupt-urierror.json
@@ -39,7 +39,8 @@
                       "value": "./eval-rqstd-abrupt-err-uri_FIXTURE.js",
                       "raw": "'./eval-rqstd-abrupt-err-uri_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   },
                   "property": {
                     "type": "Identifier",

--- a/test/language/expressions/dynamic-import/catch/nested-block-import-catch-eval-script-code-target.json
+++ b/test/language/expressions/dynamic-import/catch/nested-block-import-catch-eval-script-code-target.json
@@ -39,7 +39,8 @@
                       "value": "./script-code_FIXTURE.js",
                       "raw": "'./script-code_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   },
                   "property": {
                     "type": "Identifier",

--- a/test/language/expressions/dynamic-import/catch/nested-block-import-catch-file-does-not-exist.json
+++ b/test/language/expressions/dynamic-import/catch/nested-block-import-catch-file-does-not-exist.json
@@ -39,7 +39,8 @@
                       "value": "./THIS_FILE_DOES_NOT_EXIST.js",
                       "raw": "'./THIS_FILE_DOES_NOT_EXIST.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   },
                   "property": {
                     "type": "Identifier",

--- a/test/language/expressions/dynamic-import/catch/nested-block-import-catch-instn-iee-err-ambiguous-import.json
+++ b/test/language/expressions/dynamic-import/catch/nested-block-import-catch-instn-iee-err-ambiguous-import.json
@@ -39,7 +39,8 @@
                       "value": "./instn-iee-err-ambiguous-export_FIXTURE.js",
                       "raw": "'./instn-iee-err-ambiguous-export_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   },
                   "property": {
                     "type": "Identifier",

--- a/test/language/expressions/dynamic-import/catch/nested-block-import-catch-instn-iee-err-circular.json
+++ b/test/language/expressions/dynamic-import/catch/nested-block-import-catch-instn-iee-err-circular.json
@@ -39,7 +39,8 @@
                       "value": "./instn-iee-err-circular-1_FIXTURE.js",
                       "raw": "'./instn-iee-err-circular-1_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   },
                   "property": {
                     "type": "Identifier",

--- a/test/language/expressions/dynamic-import/catch/nested-block-import-catch-specifier-tostring-abrupt-rejects.json
+++ b/test/language/expressions/dynamic-import/catch/nested-block-import-catch-specifier-tostring-abrupt-rejects.json
@@ -108,7 +108,8 @@
                       "end": 1768,
                       "name": "obj"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   },
                   "property": {
                     "type": "Identifier",

--- a/test/language/expressions/dynamic-import/catch/nested-block-labeled-eval-rqstd-abrupt-typeerror.json
+++ b/test/language/expressions/dynamic-import/catch/nested-block-labeled-eval-rqstd-abrupt-typeerror.json
@@ -43,7 +43,8 @@
                         "value": "./eval-rqstd-abrupt-err-type_FIXTURE.js",
                         "raw": "'./eval-rqstd-abrupt-err-type_FIXTURE.js'"
                       },
-                      "options": null
+                      "options": null,
+                      "phase": null
                     },
                     "property": {
                       "type": "Identifier",

--- a/test/language/expressions/dynamic-import/catch/nested-block-labeled-eval-rqstd-abrupt-urierror.json
+++ b/test/language/expressions/dynamic-import/catch/nested-block-labeled-eval-rqstd-abrupt-urierror.json
@@ -43,7 +43,8 @@
                         "value": "./eval-rqstd-abrupt-err-uri_FIXTURE.js",
                         "raw": "'./eval-rqstd-abrupt-err-uri_FIXTURE.js'"
                       },
-                      "options": null
+                      "options": null,
+                      "phase": null
                     },
                     "property": {
                       "type": "Identifier",

--- a/test/language/expressions/dynamic-import/catch/nested-block-labeled-eval-script-code-target.json
+++ b/test/language/expressions/dynamic-import/catch/nested-block-labeled-eval-script-code-target.json
@@ -43,7 +43,8 @@
                         "value": "./script-code_FIXTURE.js",
                         "raw": "'./script-code_FIXTURE.js'"
                       },
-                      "options": null
+                      "options": null,
+                      "phase": null
                     },
                     "property": {
                       "type": "Identifier",

--- a/test/language/expressions/dynamic-import/catch/nested-block-labeled-file-does-not-exist.json
+++ b/test/language/expressions/dynamic-import/catch/nested-block-labeled-file-does-not-exist.json
@@ -43,7 +43,8 @@
                         "value": "./THIS_FILE_DOES_NOT_EXIST.js",
                         "raw": "'./THIS_FILE_DOES_NOT_EXIST.js'"
                       },
-                      "options": null
+                      "options": null,
+                      "phase": null
                     },
                     "property": {
                       "type": "Identifier",

--- a/test/language/expressions/dynamic-import/catch/nested-block-labeled-instn-iee-err-ambiguous-import.json
+++ b/test/language/expressions/dynamic-import/catch/nested-block-labeled-instn-iee-err-ambiguous-import.json
@@ -43,7 +43,8 @@
                         "value": "./instn-iee-err-ambiguous-export_FIXTURE.js",
                         "raw": "'./instn-iee-err-ambiguous-export_FIXTURE.js'"
                       },
-                      "options": null
+                      "options": null,
+                      "phase": null
                     },
                     "property": {
                       "type": "Identifier",

--- a/test/language/expressions/dynamic-import/catch/nested-block-labeled-instn-iee-err-circular.json
+++ b/test/language/expressions/dynamic-import/catch/nested-block-labeled-instn-iee-err-circular.json
@@ -43,7 +43,8 @@
                         "value": "./instn-iee-err-circular-1_FIXTURE.js",
                         "raw": "'./instn-iee-err-circular-1_FIXTURE.js'"
                       },
-                      "options": null
+                      "options": null,
+                      "phase": null
                     },
                     "property": {
                       "type": "Identifier",

--- a/test/language/expressions/dynamic-import/catch/nested-block-labeled-specifier-tostring-abrupt-rejects.json
+++ b/test/language/expressions/dynamic-import/catch/nested-block-labeled-specifier-tostring-abrupt-rejects.json
@@ -112,7 +112,8 @@
                         "end": 1790,
                         "name": "obj"
                       },
-                      "options": null
+                      "options": null,
+                      "phase": null
                     },
                     "property": {
                       "type": "Identifier",

--- a/test/language/expressions/dynamic-import/catch/nested-do-while-eval-rqstd-abrupt-typeerror.json
+++ b/test/language/expressions/dynamic-import/catch/nested-do-while-eval-rqstd-abrupt-typeerror.json
@@ -43,7 +43,8 @@
                         "value": "./eval-rqstd-abrupt-err-type_FIXTURE.js",
                         "raw": "'./eval-rqstd-abrupt-err-type_FIXTURE.js'"
                       },
-                      "options": null
+                      "options": null,
+                      "phase": null
                     },
                     "property": {
                       "type": "Identifier",

--- a/test/language/expressions/dynamic-import/catch/nested-do-while-eval-rqstd-abrupt-urierror.json
+++ b/test/language/expressions/dynamic-import/catch/nested-do-while-eval-rqstd-abrupt-urierror.json
@@ -43,7 +43,8 @@
                         "value": "./eval-rqstd-abrupt-err-uri_FIXTURE.js",
                         "raw": "'./eval-rqstd-abrupt-err-uri_FIXTURE.js'"
                       },
-                      "options": null
+                      "options": null,
+                      "phase": null
                     },
                     "property": {
                       "type": "Identifier",

--- a/test/language/expressions/dynamic-import/catch/nested-do-while-eval-script-code-target.json
+++ b/test/language/expressions/dynamic-import/catch/nested-do-while-eval-script-code-target.json
@@ -43,7 +43,8 @@
                         "value": "./script-code_FIXTURE.js",
                         "raw": "'./script-code_FIXTURE.js'"
                       },
-                      "options": null
+                      "options": null,
+                      "phase": null
                     },
                     "property": {
                       "type": "Identifier",

--- a/test/language/expressions/dynamic-import/catch/nested-do-while-file-does-not-exist.json
+++ b/test/language/expressions/dynamic-import/catch/nested-do-while-file-does-not-exist.json
@@ -43,7 +43,8 @@
                         "value": "./THIS_FILE_DOES_NOT_EXIST.js",
                         "raw": "'./THIS_FILE_DOES_NOT_EXIST.js'"
                       },
-                      "options": null
+                      "options": null,
+                      "phase": null
                     },
                     "property": {
                       "type": "Identifier",

--- a/test/language/expressions/dynamic-import/catch/nested-do-while-instn-iee-err-ambiguous-import.json
+++ b/test/language/expressions/dynamic-import/catch/nested-do-while-instn-iee-err-ambiguous-import.json
@@ -43,7 +43,8 @@
                         "value": "./instn-iee-err-ambiguous-export_FIXTURE.js",
                         "raw": "'./instn-iee-err-ambiguous-export_FIXTURE.js'"
                       },
-                      "options": null
+                      "options": null,
+                      "phase": null
                     },
                     "property": {
                       "type": "Identifier",

--- a/test/language/expressions/dynamic-import/catch/nested-do-while-instn-iee-err-circular.json
+++ b/test/language/expressions/dynamic-import/catch/nested-do-while-instn-iee-err-circular.json
@@ -43,7 +43,8 @@
                         "value": "./instn-iee-err-circular-1_FIXTURE.js",
                         "raw": "'./instn-iee-err-circular-1_FIXTURE.js'"
                       },
-                      "options": null
+                      "options": null,
+                      "phase": null
                     },
                     "property": {
                       "type": "Identifier",

--- a/test/language/expressions/dynamic-import/catch/nested-do-while-specifier-tostring-abrupt-rejects.json
+++ b/test/language/expressions/dynamic-import/catch/nested-do-while-specifier-tostring-abrupt-rejects.json
@@ -112,7 +112,8 @@
                         "end": 1784,
                         "name": "obj"
                       },
-                      "options": null
+                      "options": null,
+                      "phase": null
                     },
                     "property": {
                       "type": "Identifier",

--- a/test/language/expressions/dynamic-import/catch/nested-else-import-catch-eval-rqstd-abrupt-typeerror.json
+++ b/test/language/expressions/dynamic-import/catch/nested-else-import-catch-eval-rqstd-abrupt-typeerror.json
@@ -56,7 +56,8 @@
                         "value": "./eval-rqstd-abrupt-err-type_FIXTURE.js",
                         "raw": "'./eval-rqstd-abrupt-err-type_FIXTURE.js'"
                       },
-                      "options": null
+                      "options": null,
+                      "phase": null
                     },
                     "property": {
                       "type": "Identifier",

--- a/test/language/expressions/dynamic-import/catch/nested-else-import-catch-eval-rqstd-abrupt-urierror.json
+++ b/test/language/expressions/dynamic-import/catch/nested-else-import-catch-eval-rqstd-abrupt-urierror.json
@@ -56,7 +56,8 @@
                         "value": "./eval-rqstd-abrupt-err-uri_FIXTURE.js",
                         "raw": "'./eval-rqstd-abrupt-err-uri_FIXTURE.js'"
                       },
-                      "options": null
+                      "options": null,
+                      "phase": null
                     },
                     "property": {
                       "type": "Identifier",

--- a/test/language/expressions/dynamic-import/catch/nested-else-import-catch-eval-script-code-target.json
+++ b/test/language/expressions/dynamic-import/catch/nested-else-import-catch-eval-script-code-target.json
@@ -56,7 +56,8 @@
                         "value": "./script-code_FIXTURE.js",
                         "raw": "'./script-code_FIXTURE.js'"
                       },
-                      "options": null
+                      "options": null,
+                      "phase": null
                     },
                     "property": {
                       "type": "Identifier",

--- a/test/language/expressions/dynamic-import/catch/nested-else-import-catch-file-does-not-exist.json
+++ b/test/language/expressions/dynamic-import/catch/nested-else-import-catch-file-does-not-exist.json
@@ -56,7 +56,8 @@
                         "value": "./THIS_FILE_DOES_NOT_EXIST.js",
                         "raw": "'./THIS_FILE_DOES_NOT_EXIST.js'"
                       },
-                      "options": null
+                      "options": null,
+                      "phase": null
                     },
                     "property": {
                       "type": "Identifier",

--- a/test/language/expressions/dynamic-import/catch/nested-else-import-catch-instn-iee-err-ambiguous-import.json
+++ b/test/language/expressions/dynamic-import/catch/nested-else-import-catch-instn-iee-err-ambiguous-import.json
@@ -56,7 +56,8 @@
                         "value": "./instn-iee-err-ambiguous-export_FIXTURE.js",
                         "raw": "'./instn-iee-err-ambiguous-export_FIXTURE.js'"
                       },
-                      "options": null
+                      "options": null,
+                      "phase": null
                     },
                     "property": {
                       "type": "Identifier",

--- a/test/language/expressions/dynamic-import/catch/nested-else-import-catch-instn-iee-err-circular.json
+++ b/test/language/expressions/dynamic-import/catch/nested-else-import-catch-instn-iee-err-circular.json
@@ -56,7 +56,8 @@
                         "value": "./instn-iee-err-circular-1_FIXTURE.js",
                         "raw": "'./instn-iee-err-circular-1_FIXTURE.js'"
                       },
-                      "options": null
+                      "options": null,
+                      "phase": null
                     },
                     "property": {
                       "type": "Identifier",

--- a/test/language/expressions/dynamic-import/catch/nested-else-import-catch-specifier-tostring-abrupt-rejects.json
+++ b/test/language/expressions/dynamic-import/catch/nested-else-import-catch-specifier-tostring-abrupt-rejects.json
@@ -125,7 +125,8 @@
                         "end": 1787,
                         "name": "obj"
                       },
-                      "options": null
+                      "options": null,
+                      "phase": null
                     },
                     "property": {
                       "type": "Identifier",

--- a/test/language/expressions/dynamic-import/catch/nested-function-import-catch-eval-rqstd-abrupt-typeerror.json
+++ b/test/language/expressions/dynamic-import/catch/nested-function-import-catch-eval-rqstd-abrupt-typeerror.json
@@ -53,7 +53,8 @@
                         "value": "./eval-rqstd-abrupt-err-type_FIXTURE.js",
                         "raw": "'./eval-rqstd-abrupt-err-type_FIXTURE.js'"
                       },
-                      "options": null
+                      "options": null,
+                      "phase": null
                     },
                     "property": {
                       "type": "Identifier",

--- a/test/language/expressions/dynamic-import/catch/nested-function-import-catch-eval-rqstd-abrupt-urierror.json
+++ b/test/language/expressions/dynamic-import/catch/nested-function-import-catch-eval-rqstd-abrupt-urierror.json
@@ -53,7 +53,8 @@
                         "value": "./eval-rqstd-abrupt-err-uri_FIXTURE.js",
                         "raw": "'./eval-rqstd-abrupt-err-uri_FIXTURE.js'"
                       },
-                      "options": null
+                      "options": null,
+                      "phase": null
                     },
                     "property": {
                       "type": "Identifier",

--- a/test/language/expressions/dynamic-import/catch/nested-function-import-catch-eval-script-code-target.json
+++ b/test/language/expressions/dynamic-import/catch/nested-function-import-catch-eval-script-code-target.json
@@ -53,7 +53,8 @@
                         "value": "./script-code_FIXTURE.js",
                         "raw": "'./script-code_FIXTURE.js'"
                       },
-                      "options": null
+                      "options": null,
+                      "phase": null
                     },
                     "property": {
                       "type": "Identifier",

--- a/test/language/expressions/dynamic-import/catch/nested-function-import-catch-file-does-not-exist.json
+++ b/test/language/expressions/dynamic-import/catch/nested-function-import-catch-file-does-not-exist.json
@@ -53,7 +53,8 @@
                         "value": "./THIS_FILE_DOES_NOT_EXIST.js",
                         "raw": "'./THIS_FILE_DOES_NOT_EXIST.js'"
                       },
-                      "options": null
+                      "options": null,
+                      "phase": null
                     },
                     "property": {
                       "type": "Identifier",

--- a/test/language/expressions/dynamic-import/catch/nested-function-import-catch-instn-iee-err-ambiguous-import.json
+++ b/test/language/expressions/dynamic-import/catch/nested-function-import-catch-instn-iee-err-ambiguous-import.json
@@ -53,7 +53,8 @@
                         "value": "./instn-iee-err-ambiguous-export_FIXTURE.js",
                         "raw": "'./instn-iee-err-ambiguous-export_FIXTURE.js'"
                       },
-                      "options": null
+                      "options": null,
+                      "phase": null
                     },
                     "property": {
                       "type": "Identifier",

--- a/test/language/expressions/dynamic-import/catch/nested-function-import-catch-instn-iee-err-circular.json
+++ b/test/language/expressions/dynamic-import/catch/nested-function-import-catch-instn-iee-err-circular.json
@@ -53,7 +53,8 @@
                         "value": "./instn-iee-err-circular-1_FIXTURE.js",
                         "raw": "'./instn-iee-err-circular-1_FIXTURE.js'"
                       },
-                      "options": null
+                      "options": null,
+                      "phase": null
                     },
                     "property": {
                       "type": "Identifier",

--- a/test/language/expressions/dynamic-import/catch/nested-function-import-catch-specifier-tostring-abrupt-rejects.json
+++ b/test/language/expressions/dynamic-import/catch/nested-function-import-catch-specifier-tostring-abrupt-rejects.json
@@ -122,7 +122,8 @@
                         "end": 1787,
                         "name": "obj"
                       },
-                      "options": null
+                      "options": null,
+                      "phase": null
                     },
                     "property": {
                       "type": "Identifier",

--- a/test/language/expressions/dynamic-import/catch/nested-if-import-catch-eval-rqstd-abrupt-typeerror.json
+++ b/test/language/expressions/dynamic-import/catch/nested-if-import-catch-eval-rqstd-abrupt-typeerror.json
@@ -50,7 +50,8 @@
                         "value": "./eval-rqstd-abrupt-err-type_FIXTURE.js",
                         "raw": "'./eval-rqstd-abrupt-err-type_FIXTURE.js'"
                       },
-                      "options": null
+                      "options": null,
+                      "phase": null
                     },
                     "property": {
                       "type": "Identifier",

--- a/test/language/expressions/dynamic-import/catch/nested-if-import-catch-eval-rqstd-abrupt-urierror.json
+++ b/test/language/expressions/dynamic-import/catch/nested-if-import-catch-eval-rqstd-abrupt-urierror.json
@@ -50,7 +50,8 @@
                         "value": "./eval-rqstd-abrupt-err-uri_FIXTURE.js",
                         "raw": "'./eval-rqstd-abrupt-err-uri_FIXTURE.js'"
                       },
-                      "options": null
+                      "options": null,
+                      "phase": null
                     },
                     "property": {
                       "type": "Identifier",

--- a/test/language/expressions/dynamic-import/catch/nested-if-import-catch-eval-script-code-target.json
+++ b/test/language/expressions/dynamic-import/catch/nested-if-import-catch-eval-script-code-target.json
@@ -50,7 +50,8 @@
                         "value": "./script-code_FIXTURE.js",
                         "raw": "'./script-code_FIXTURE.js'"
                       },
-                      "options": null
+                      "options": null,
+                      "phase": null
                     },
                     "property": {
                       "type": "Identifier",

--- a/test/language/expressions/dynamic-import/catch/nested-if-import-catch-file-does-not-exist.json
+++ b/test/language/expressions/dynamic-import/catch/nested-if-import-catch-file-does-not-exist.json
@@ -50,7 +50,8 @@
                         "value": "./THIS_FILE_DOES_NOT_EXIST.js",
                         "raw": "'./THIS_FILE_DOES_NOT_EXIST.js'"
                       },
-                      "options": null
+                      "options": null,
+                      "phase": null
                     },
                     "property": {
                       "type": "Identifier",

--- a/test/language/expressions/dynamic-import/catch/nested-if-import-catch-instn-iee-err-ambiguous-import.json
+++ b/test/language/expressions/dynamic-import/catch/nested-if-import-catch-instn-iee-err-ambiguous-import.json
@@ -50,7 +50,8 @@
                         "value": "./instn-iee-err-ambiguous-export_FIXTURE.js",
                         "raw": "'./instn-iee-err-ambiguous-export_FIXTURE.js'"
                       },
-                      "options": null
+                      "options": null,
+                      "phase": null
                     },
                     "property": {
                       "type": "Identifier",

--- a/test/language/expressions/dynamic-import/catch/nested-if-import-catch-instn-iee-err-circular.json
+++ b/test/language/expressions/dynamic-import/catch/nested-if-import-catch-instn-iee-err-circular.json
@@ -50,7 +50,8 @@
                         "value": "./instn-iee-err-circular-1_FIXTURE.js",
                         "raw": "'./instn-iee-err-circular-1_FIXTURE.js'"
                       },
-                      "options": null
+                      "options": null,
+                      "phase": null
                     },
                     "property": {
                       "type": "Identifier",

--- a/test/language/expressions/dynamic-import/catch/nested-if-import-catch-specifier-tostring-abrupt-rejects.json
+++ b/test/language/expressions/dynamic-import/catch/nested-if-import-catch-specifier-tostring-abrupt-rejects.json
@@ -119,7 +119,8 @@
                         "end": 1772,
                         "name": "obj"
                       },
-                      "options": null
+                      "options": null,
+                      "phase": null
                     },
                     "property": {
                       "type": "Identifier",

--- a/test/language/expressions/dynamic-import/catch/nested-while-import-catch-eval-rqstd-abrupt-typeerror.json
+++ b/test/language/expressions/dynamic-import/catch/nested-while-import-catch-eval-rqstd-abrupt-typeerror.json
@@ -100,7 +100,8 @@
                         "value": "./eval-rqstd-abrupt-err-type_FIXTURE.js",
                         "raw": "'./eval-rqstd-abrupt-err-type_FIXTURE.js'"
                       },
-                      "options": null
+                      "options": null,
+                      "phase": null
                     },
                     "property": {
                       "type": "Identifier",

--- a/test/language/expressions/dynamic-import/catch/nested-while-import-catch-eval-rqstd-abrupt-urierror.json
+++ b/test/language/expressions/dynamic-import/catch/nested-while-import-catch-eval-rqstd-abrupt-urierror.json
@@ -100,7 +100,8 @@
                         "value": "./eval-rqstd-abrupt-err-uri_FIXTURE.js",
                         "raw": "'./eval-rqstd-abrupt-err-uri_FIXTURE.js'"
                       },
-                      "options": null
+                      "options": null,
+                      "phase": null
                     },
                     "property": {
                       "type": "Identifier",

--- a/test/language/expressions/dynamic-import/catch/nested-while-import-catch-eval-script-code-target.json
+++ b/test/language/expressions/dynamic-import/catch/nested-while-import-catch-eval-script-code-target.json
@@ -100,7 +100,8 @@
                         "value": "./script-code_FIXTURE.js",
                         "raw": "'./script-code_FIXTURE.js'"
                       },
-                      "options": null
+                      "options": null,
+                      "phase": null
                     },
                     "property": {
                       "type": "Identifier",

--- a/test/language/expressions/dynamic-import/catch/nested-while-import-catch-file-does-not-exist.json
+++ b/test/language/expressions/dynamic-import/catch/nested-while-import-catch-file-does-not-exist.json
@@ -100,7 +100,8 @@
                         "value": "./THIS_FILE_DOES_NOT_EXIST.js",
                         "raw": "'./THIS_FILE_DOES_NOT_EXIST.js'"
                       },
-                      "options": null
+                      "options": null,
+                      "phase": null
                     },
                     "property": {
                       "type": "Identifier",

--- a/test/language/expressions/dynamic-import/catch/nested-while-import-catch-instn-iee-err-ambiguous-import.json
+++ b/test/language/expressions/dynamic-import/catch/nested-while-import-catch-instn-iee-err-ambiguous-import.json
@@ -100,7 +100,8 @@
                         "value": "./instn-iee-err-ambiguous-export_FIXTURE.js",
                         "raw": "'./instn-iee-err-ambiguous-export_FIXTURE.js'"
                       },
-                      "options": null
+                      "options": null,
+                      "phase": null
                     },
                     "property": {
                       "type": "Identifier",

--- a/test/language/expressions/dynamic-import/catch/nested-while-import-catch-instn-iee-err-circular.json
+++ b/test/language/expressions/dynamic-import/catch/nested-while-import-catch-instn-iee-err-circular.json
@@ -100,7 +100,8 @@
                         "value": "./instn-iee-err-circular-1_FIXTURE.js",
                         "raw": "'./instn-iee-err-circular-1_FIXTURE.js'"
                       },
-                      "options": null
+                      "options": null,
+                      "phase": null
                     },
                     "property": {
                       "type": "Identifier",

--- a/test/language/expressions/dynamic-import/catch/nested-while-import-catch-specifier-tostring-abrupt-rejects.json
+++ b/test/language/expressions/dynamic-import/catch/nested-while-import-catch-specifier-tostring-abrupt-rejects.json
@@ -169,7 +169,8 @@
                         "end": 1797,
                         "name": "obj"
                       },
-                      "options": null
+                      "options": null,
+                      "phase": null
                     },
                     "property": {
                       "type": "Identifier",

--- a/test/language/expressions/dynamic-import/catch/top-level-import-catch-eval-rqstd-abrupt-typeerror.json
+++ b/test/language/expressions/dynamic-import/catch/top-level-import-catch-eval-rqstd-abrupt-typeerror.json
@@ -34,7 +34,8 @@
                   "value": "./eval-rqstd-abrupt-err-type_FIXTURE.js",
                   "raw": "'./eval-rqstd-abrupt-err-type_FIXTURE.js'"
                 },
-                "options": null
+                "options": null,
+                "phase": null
               },
               "property": {
                 "type": "Identifier",

--- a/test/language/expressions/dynamic-import/catch/top-level-import-catch-eval-rqstd-abrupt-urierror.json
+++ b/test/language/expressions/dynamic-import/catch/top-level-import-catch-eval-rqstd-abrupt-urierror.json
@@ -34,7 +34,8 @@
                   "value": "./eval-rqstd-abrupt-err-uri_FIXTURE.js",
                   "raw": "'./eval-rqstd-abrupt-err-uri_FIXTURE.js'"
                 },
-                "options": null
+                "options": null,
+                "phase": null
               },
               "property": {
                 "type": "Identifier",

--- a/test/language/expressions/dynamic-import/catch/top-level-import-catch-eval-script-code-target.json
+++ b/test/language/expressions/dynamic-import/catch/top-level-import-catch-eval-script-code-target.json
@@ -34,7 +34,8 @@
                   "value": "./script-code_FIXTURE.js",
                   "raw": "'./script-code_FIXTURE.js'"
                 },
-                "options": null
+                "options": null,
+                "phase": null
               },
               "property": {
                 "type": "Identifier",

--- a/test/language/expressions/dynamic-import/catch/top-level-import-catch-file-does-not-exist.json
+++ b/test/language/expressions/dynamic-import/catch/top-level-import-catch-file-does-not-exist.json
@@ -34,7 +34,8 @@
                   "value": "./THIS_FILE_DOES_NOT_EXIST.js",
                   "raw": "'./THIS_FILE_DOES_NOT_EXIST.js'"
                 },
-                "options": null
+                "options": null,
+                "phase": null
               },
               "property": {
                 "type": "Identifier",

--- a/test/language/expressions/dynamic-import/catch/top-level-import-catch-instn-iee-err-ambiguous-import.json
+++ b/test/language/expressions/dynamic-import/catch/top-level-import-catch-instn-iee-err-ambiguous-import.json
@@ -34,7 +34,8 @@
                   "value": "./instn-iee-err-ambiguous-export_FIXTURE.js",
                   "raw": "'./instn-iee-err-ambiguous-export_FIXTURE.js'"
                 },
-                "options": null
+                "options": null,
+                "phase": null
               },
               "property": {
                 "type": "Identifier",

--- a/test/language/expressions/dynamic-import/catch/top-level-import-catch-instn-iee-err-circular.json
+++ b/test/language/expressions/dynamic-import/catch/top-level-import-catch-instn-iee-err-circular.json
@@ -34,7 +34,8 @@
                   "value": "./instn-iee-err-circular-1_FIXTURE.js",
                   "raw": "'./instn-iee-err-circular-1_FIXTURE.js'"
                 },
-                "options": null
+                "options": null,
+                "phase": null
               },
               "property": {
                 "type": "Identifier",

--- a/test/language/expressions/dynamic-import/catch/top-level-import-catch-specifier-tostring-abrupt-rejects.json
+++ b/test/language/expressions/dynamic-import/catch/top-level-import-catch-specifier-tostring-abrupt-rejects.json
@@ -103,7 +103,8 @@
                   "end": 1758,
                   "name": "obj"
                 },
-                "options": null
+                "options": null,
+                "phase": null
               },
               "property": {
                 "type": "Identifier",

--- a/test/language/expressions/dynamic-import/custom-primitive.json
+++ b/test/language/expressions/dynamic-import/custom-primitive.json
@@ -52,7 +52,8 @@
                       "value": "./custom-tostring_FIXTURE.js",
                       "raw": "'./custom-tostring_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   }
                 }
               }
@@ -89,7 +90,8 @@
                       "value": "./custom-valueof_FIXTURE.js",
                       "raw": "'./custom-valueof_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   }
                 }
               }

--- a/test/language/expressions/dynamic-import/eval-export-dflt-cls-anon.json
+++ b/test/language/expressions/dynamic-import/eval-export-dflt-cls-anon.json
@@ -104,7 +104,8 @@
                       "value": "./eval-export-dflt-cls-anon.js",
                       "raw": "'./eval-export-dflt-cls-anon.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   },
                   "property": {
                     "type": "Identifier",

--- a/test/language/expressions/dynamic-import/eval-export-dflt-cls-name-meth.json
+++ b/test/language/expressions/dynamic-import/eval-export-dflt-cls-name-meth.json
@@ -104,7 +104,8 @@
                       "value": "./eval-export-dflt-cls-name-meth.js",
                       "raw": "'./eval-export-dflt-cls-name-meth.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   },
                   "property": {
                     "type": "Identifier",

--- a/test/language/expressions/dynamic-import/eval-export-dflt-cls-named.json
+++ b/test/language/expressions/dynamic-import/eval-export-dflt-cls-named.json
@@ -109,7 +109,8 @@
                       "value": "./eval-export-dflt-cls-named.js",
                       "raw": "'./eval-export-dflt-cls-named.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   },
                   "property": {
                     "type": "Identifier",

--- a/test/language/expressions/dynamic-import/eval-export-dflt-expr-cls-anon.json
+++ b/test/language/expressions/dynamic-import/eval-export-dflt-expr-cls-anon.json
@@ -109,7 +109,8 @@
                       "value": "./eval-export-dflt-expr-cls-anon.js",
                       "raw": "'./eval-export-dflt-expr-cls-anon.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   },
                   "property": {
                     "type": "Identifier",

--- a/test/language/expressions/dynamic-import/eval-export-dflt-expr-cls-name-meth.json
+++ b/test/language/expressions/dynamic-import/eval-export-dflt-expr-cls-name-meth.json
@@ -109,7 +109,8 @@
                       "value": "./eval-export-dflt-expr-cls-name-meth.js",
                       "raw": "'./eval-export-dflt-expr-cls-name-meth.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   },
                   "property": {
                     "type": "Identifier",

--- a/test/language/expressions/dynamic-import/eval-export-dflt-expr-cls-named.json
+++ b/test/language/expressions/dynamic-import/eval-export-dflt-expr-cls-named.json
@@ -114,7 +114,8 @@
                       "value": "./eval-export-dflt-expr-cls-named.js",
                       "raw": "'./eval-export-dflt-expr-cls-named.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   },
                   "property": {
                     "type": "Identifier",

--- a/test/language/expressions/dynamic-import/eval-export-dflt-expr-fn-anon.json
+++ b/test/language/expressions/dynamic-import/eval-export-dflt-expr-fn-anon.json
@@ -81,7 +81,8 @@
                       "value": "./eval-export-dflt-expr-fn-anon.js",
                       "raw": "'./eval-export-dflt-expr-fn-anon.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   },
                   "property": {
                     "type": "Identifier",

--- a/test/language/expressions/dynamic-import/eval-export-dflt-expr-fn-named.json
+++ b/test/language/expressions/dynamic-import/eval-export-dflt-expr-fn-named.json
@@ -86,7 +86,8 @@
                       "value": "./eval-export-dflt-expr-fn-named.js",
                       "raw": "'./eval-export-dflt-expr-fn-named.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   },
                   "property": {
                     "type": "Identifier",

--- a/test/language/expressions/dynamic-import/eval-export-dflt-expr-gen-anon.json
+++ b/test/language/expressions/dynamic-import/eval-export-dflt-expr-gen-anon.json
@@ -81,7 +81,8 @@
                       "value": "./eval-export-dflt-expr-gen-anon.js",
                       "raw": "'./eval-export-dflt-expr-gen-anon.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   },
                   "property": {
                     "type": "Identifier",

--- a/test/language/expressions/dynamic-import/eval-export-dflt-expr-gen-named.json
+++ b/test/language/expressions/dynamic-import/eval-export-dflt-expr-gen-named.json
@@ -86,7 +86,8 @@
                       "value": "./eval-export-dflt-expr-gen-named.js",
                       "raw": "'./eval-export-dflt-expr-gen-named.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   },
                   "property": {
                     "type": "Identifier",

--- a/test/language/expressions/dynamic-import/eval-export-dflt-expr-in.json
+++ b/test/language/expressions/dynamic-import/eval-export-dflt-expr-in.json
@@ -114,7 +114,8 @@
                       "value": "./eval-export-dflt-expr-in.js",
                       "raw": "'./eval-export-dflt-expr-in.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   },
                   "property": {
                     "type": "Identifier",

--- a/test/language/expressions/dynamic-import/eval-rqstd-once.json
+++ b/test/language/expressions/dynamic-import/eval-rqstd-once.json
@@ -95,7 +95,8 @@
                           "value": "./eval-rqstd-once_FIXTURE.js",
                           "raw": "'./eval-rqstd-once_FIXTURE.js'"
                         },
-                        "options": null
+                        "options": null,
+                        "phase": null
                       },
                       {
                         "type": "ImportExpression",
@@ -108,7 +109,8 @@
                           "value": "./eval-rqstd-once_FIXTURE.js",
                           "raw": "'./eval-rqstd-once_FIXTURE.js'"
                         },
-                        "options": null
+                        "options": null,
+                        "phase": null
                       }
                     ]
                   }
@@ -158,7 +160,8 @@
                             "value": "./eval-rqstd-once_FIXTURE.js",
                             "raw": "'./eval-rqstd-once_FIXTURE.js'"
                           },
-                          "options": null
+                          "options": null,
+                          "phase": null
                         }
                       }
                     },
@@ -181,7 +184,8 @@
                             "value": "./eval-rqstd-once_FIXTURE.js",
                             "raw": "'./eval-rqstd-once_FIXTURE.js'"
                           },
-                          "options": null
+                          "options": null,
+                          "phase": null
                         }
                       }
                     },

--- a/test/language/expressions/dynamic-import/eval-self-once-module.json
+++ b/test/language/expressions/dynamic-import/eval-self-once-module.json
@@ -215,7 +215,8 @@
                           "value": "./eval-self-once-module.js",
                           "raw": "'./eval-self-once-module.js'"
                         },
-                        "options": null
+                        "options": null,
+                        "phase": null
                       },
                       {
                         "type": "ImportExpression",
@@ -228,7 +229,8 @@
                           "value": "./eval-self-once-module.js",
                           "raw": "'./eval-self-once-module.js'"
                         },
-                        "options": null
+                        "options": null,
+                        "phase": null
                       }
                     ]
                   }
@@ -278,7 +280,8 @@
                             "value": "./eval-self-once-module.js",
                             "raw": "'./eval-self-once-module.js'"
                           },
-                          "options": null
+                          "options": null,
+                          "phase": null
                         }
                       }
                     },
@@ -301,7 +304,8 @@
                             "value": "./eval-self-once-module.js",
                             "raw": "'./eval-self-once-module.js'"
                           },
-                          "options": null
+                          "options": null,
+                          "phase": null
                         }
                       }
                     },

--- a/test/language/expressions/dynamic-import/eval-self-once-script.json
+++ b/test/language/expressions/dynamic-import/eval-self-once-script.json
@@ -243,7 +243,8 @@
                           "value": "./eval-self-once-script.js",
                           "raw": "'./eval-self-once-script.js'"
                         },
-                        "options": null
+                        "options": null,
+                        "phase": null
                       },
                       {
                         "type": "ImportExpression",
@@ -256,7 +257,8 @@
                           "value": "./eval-self-once-script.js",
                           "raw": "'./eval-self-once-script.js'"
                         },
-                        "options": null
+                        "options": null,
+                        "phase": null
                       }
                     ]
                   }
@@ -306,7 +308,8 @@
                             "value": "./eval-self-once-script.js",
                             "raw": "'./eval-self-once-script.js'"
                           },
-                          "options": null
+                          "options": null,
+                          "phase": null
                         }
                       }
                     },
@@ -329,7 +332,8 @@
                             "value": "./eval-self-once-script.js",
                             "raw": "'./eval-self-once-script.js'"
                           },
-                          "options": null
+                          "options": null,
+                          "phase": null
                         }
                       }
                     },

--- a/test/language/expressions/dynamic-import/for-await-resolution-and-error-agen-yield.json
+++ b/test/language/expressions/dynamic-import/for-await-resolution-and-error-agen-yield.json
@@ -42,7 +42,8 @@
                   "value": "./for-await-resolution-and-error-a_FIXTURE.js",
                   "raw": "'./for-await-resolution-and-error-a_FIXTURE.js'"
                 },
-                "options": null
+                "options": null,
+                "phase": null
               }
             }
           },
@@ -66,7 +67,8 @@
                   "value": "./for-await-resolution-and-error-b_FIXTURE.js",
                   "raw": "'./for-await-resolution-and-error-b_FIXTURE.js'"
                 },
-                "options": null
+                "options": null,
+                "phase": null
               }
             }
           },
@@ -90,7 +92,8 @@
                   "value": "./for-await-resolution-and-error-poisoned_FIXTURE.js",
                   "raw": "'./for-await-resolution-and-error-poisoned_FIXTURE.js'"
                 },
-                "options": null
+                "options": null,
+                "phase": null
               }
             }
           }
@@ -140,7 +143,8 @@
                     "value": "./for-await-resolution-and-error-a_FIXTURE.js",
                     "raw": "'./for-await-resolution-and-error-a_FIXTURE.js'"
                   },
-                  "options": null
+                  "options": null,
+                  "phase": null
                 }
               }
             }
@@ -169,7 +173,8 @@
                     "value": "./for-await-resolution-and-error-b_FIXTURE.js",
                     "raw": "'./for-await-resolution-and-error-b_FIXTURE.js'"
                   },
-                  "options": null
+                  "options": null,
+                  "phase": null
                 }
               }
             }
@@ -198,7 +203,8 @@
                     "value": "./for-await-resolution-and-error-poisoned_FIXTURE.js",
                     "raw": "'./for-await-resolution-and-error-poisoned_FIXTURE.js'"
                   },
-                  "options": null
+                  "options": null,
+                  "phase": null
                 }
               }
             }

--- a/test/language/expressions/dynamic-import/for-await-resolution-and-error-agen.json
+++ b/test/language/expressions/dynamic-import/for-await-resolution-and-error-agen.json
@@ -63,7 +63,8 @@
                     "value": "./for-await-resolution-and-error-a_FIXTURE.js",
                     "raw": "'./for-await-resolution-and-error-a_FIXTURE.js'"
                   },
-                  "options": null
+                  "options": null,
+                  "phase": null
                 },
                 {
                   "type": "ImportExpression",
@@ -76,7 +77,8 @@
                     "value": "./for-await-resolution-and-error-b_FIXTURE.js",
                     "raw": "'./for-await-resolution-and-error-b_FIXTURE.js'"
                   },
-                  "options": null
+                  "options": null,
+                  "phase": null
                 },
                 {
                   "type": "ImportExpression",
@@ -89,7 +91,8 @@
                     "value": "./for-await-resolution-and-error-poisoned_FIXTURE.js",
                     "raw": "'./for-await-resolution-and-error-poisoned_FIXTURE.js'"
                   },
-                  "options": null
+                  "options": null,
+                  "phase": null
                 }
               ]
             },

--- a/test/language/expressions/dynamic-import/for-await-resolution-and-error.json
+++ b/test/language/expressions/dynamic-import/for-await-resolution-and-error.json
@@ -88,7 +88,8 @@
                     "value": "./for-await-resolution-and-error-a_FIXTURE.js",
                     "raw": "'./for-await-resolution-and-error-a_FIXTURE.js'"
                   },
-                  "options": null
+                  "options": null,
+                  "phase": null
                 },
                 {
                   "type": "ImportExpression",
@@ -101,7 +102,8 @@
                     "value": "./for-await-resolution-and-error-b_FIXTURE.js",
                     "raw": "'./for-await-resolution-and-error-b_FIXTURE.js'"
                   },
-                  "options": null
+                  "options": null,
+                  "phase": null
                 },
                 {
                   "type": "ImportExpression",
@@ -114,7 +116,8 @@
                     "value": "./for-await-resolution-and-error-poisoned_FIXTURE.js",
                     "raw": "'./for-await-resolution-and-error-poisoned_FIXTURE.js'"
                   },
-                  "options": null
+                  "options": null,
+                  "phase": null
                 },
                 {
                   "type": "ImportExpression",
@@ -127,7 +130,8 @@
                     "value": "./for-await-resolution-and-error-a_FIXTURE.js",
                     "raw": "'./for-await-resolution-and-error-a_FIXTURE.js'"
                   },
-                  "options": null
+                  "options": null,
+                  "phase": null
                 }
               ]
             },

--- a/test/language/expressions/dynamic-import/import-attributes/2nd-param-await-expr.json
+++ b/test/language/expressions/dynamic-import/import-attributes/2nd-param-await-expr.json
@@ -70,7 +70,8 @@
                                 "end": 663,
                                 "name": "undefined"
                               }
-                            }
+                            },
+                            "phase": null
                           }
                         }
                       ]

--- a/test/language/expressions/dynamic-import/import-attributes/2nd-param-await-ident.json
+++ b/test/language/expressions/dynamic-import/import-attributes/2nd-param-await-ident.json
@@ -74,7 +74,8 @@
                     }
                   ],
                   "optional": false
-                }
+                },
+                "phase": null
               },
               "property": {
                 "type": "Identifier",

--- a/test/language/expressions/dynamic-import/import-attributes/2nd-param-evaluation-abrupt-return.json
+++ b/test/language/expressions/dynamic-import/import-attributes/2nd-param-evaluation-abrupt-return.json
@@ -133,7 +133,8 @@
                             "end": 878,
                             "delegate": false,
                             "argument": null
-                          }
+                          },
+                          "phase": null
                         },
                         {
                           "type": "AssignmentExpression",

--- a/test/language/expressions/dynamic-import/import-attributes/2nd-param-evaluation-abrupt-throw.json
+++ b/test/language/expressions/dynamic-import/import-attributes/2nd-param-evaluation-abrupt-throw.json
@@ -193,7 +193,8 @@
                           },
                           "arguments": [],
                           "optional": false
-                        }
+                        },
+                        "phase": null
                       },
                       {
                         "type": "AssignmentExpression",

--- a/test/language/expressions/dynamic-import/import-attributes/2nd-param-evaluation-sequence.json
+++ b/test/language/expressions/dynamic-import/import-attributes/2nd-param-evaluation-sequence.json
@@ -129,7 +129,8 @@
                   }
                 ]
               }
-            }
+            },
+            "phase": null
           },
           "property": {
             "type": "Identifier",

--- a/test/language/expressions/dynamic-import/import-attributes/2nd-param-get-with-error.json
+++ b/test/language/expressions/dynamic-import/import-attributes/2nd-param-get-with-error.json
@@ -139,7 +139,8 @@
                   "start": 1022,
                   "end": 1029,
                   "name": "options"
-                }
+                },
+                "phase": null
               },
               "property": {
                 "type": "Identifier",

--- a/test/language/expressions/dynamic-import/import-attributes/2nd-param-in.json
+++ b/test/language/expressions/dynamic-import/import-attributes/2nd-param-in.json
@@ -79,7 +79,8 @@
               "end": 635,
               "name": "undefined"
             }
-          }
+          },
+          "phase": null
         }
       },
       "test": {

--- a/test/language/expressions/dynamic-import/import-attributes/2nd-param-non-object.json
+++ b/test/language/expressions/dynamic-import/import-attributes/2nd-param-non-object.json
@@ -301,7 +301,8 @@
                               "end": 1264,
                               "value": null,
                               "raw": "null"
-                            }
+                            },
+                            "phase": null
                           },
                           {
                             "type": "Literal",
@@ -341,7 +342,8 @@
                               "end": 1323,
                               "value": false,
                               "raw": "false"
-                            }
+                            },
+                            "phase": null
                           },
                           {
                             "type": "Literal",
@@ -381,7 +383,8 @@
                               "end": 1382,
                               "value": 23,
                               "raw": "23"
-                            }
+                            },
+                            "phase": null
                           },
                           {
                             "type": "Literal",
@@ -421,7 +424,8 @@
                               "end": 1440,
                               "value": "",
                               "raw": "''"
-                            }
+                            },
+                            "phase": null
                           },
                           {
                             "type": "Literal",
@@ -475,7 +479,8 @@
                                 }
                               ],
                               "optional": false
-                            }
+                            },
+                            "phase": null
                           },
                           {
                             "type": "Literal",
@@ -516,7 +521,8 @@
                               "value": null,
                               "raw": "23n",
                               "bigint": "23"
-                            }
+                            },
+                            "phase": null
                           },
                           {
                             "type": "Literal",

--- a/test/language/expressions/dynamic-import/import-attributes/2nd-param-trailing-comma-fulfill.json
+++ b/test/language/expressions/dynamic-import/import-attributes/2nd-param-trailing-comma-fulfill.json
@@ -39,7 +39,8 @@
                   "start": 605,
                   "end": 607,
                   "properties": []
-                }
+                },
+                "phase": null
               },
               "property": {
                 "type": "Identifier",

--- a/test/language/expressions/dynamic-import/import-attributes/2nd-param-trailing-comma-reject.json
+++ b/test/language/expressions/dynamic-import/import-attributes/2nd-param-trailing-comma-reject.json
@@ -113,7 +113,8 @@
                   "start": 654,
                   "end": 656,
                   "properties": []
-                }
+                },
+                "phase": null
               },
               "property": {
                 "type": "Identifier",

--- a/test/language/expressions/dynamic-import/import-attributes/2nd-param-with-enumeration-abrupt.json
+++ b/test/language/expressions/dynamic-import/import-attributes/2nd-param-with-enumeration-abrupt.json
@@ -180,7 +180,8 @@
                   "start": 1328,
                   "end": 1335,
                   "name": "options"
-                }
+                },
+                "phase": null
               },
               "property": {
                 "type": "Identifier",

--- a/test/language/expressions/dynamic-import/import-attributes/2nd-param-with-enumeration-enumerable.json
+++ b/test/language/expressions/dynamic-import/import-attributes/2nd-param-with-enumeration-enumerable.json
@@ -580,7 +580,8 @@
                   "start": 1639,
                   "end": 1646,
                   "name": "options"
-                }
+                },
+                "phase": null
               },
               "property": {
                 "type": "Identifier",

--- a/test/language/expressions/dynamic-import/import-attributes/2nd-param-with-enumeration.json
+++ b/test/language/expressions/dynamic-import/import-attributes/2nd-param-with-enumeration.json
@@ -586,7 +586,8 @@
                   "start": 1697,
                   "end": 1704,
                   "name": "options"
-                }
+                },
+                "phase": null
               },
               "property": {
                 "type": "Identifier",

--- a/test/language/expressions/dynamic-import/import-attributes/2nd-param-with-non-object.json
+++ b/test/language/expressions/dynamic-import/import-attributes/2nd-param-with-non-object.json
@@ -323,7 +323,8 @@
                                   "kind": "init"
                                 }
                               ]
-                            }
+                            },
+                            "phase": null
                           },
                           {
                             "type": "Literal",
@@ -385,7 +386,8 @@
                                   "kind": "init"
                                 }
                               ]
-                            }
+                            },
+                            "phase": null
                           },
                           {
                             "type": "Literal",
@@ -447,7 +449,8 @@
                                   "kind": "init"
                                 }
                               ]
-                            }
+                            },
+                            "phase": null
                           },
                           {
                             "type": "Literal",
@@ -509,7 +512,8 @@
                                   "kind": "init"
                                 }
                               ]
-                            }
+                            },
+                            "phase": null
                           },
                           {
                             "type": "Literal",
@@ -585,7 +589,8 @@
                                   "kind": "init"
                                 }
                               ]
-                            }
+                            },
+                            "phase": null
                           },
                           {
                             "type": "Literal",
@@ -648,7 +653,8 @@
                                   "kind": "init"
                                 }
                               ]
-                            }
+                            },
+                            "phase": null
                           },
                           {
                             "type": "Literal",

--- a/test/language/expressions/dynamic-import/import-attributes/2nd-param-with-undefined.json
+++ b/test/language/expressions/dynamic-import/import-attributes/2nd-param-with-undefined.json
@@ -68,7 +68,8 @@
                           "start": 1250,
                           "end": 1252,
                           "properties": []
-                        }
+                        },
+                        "phase": null
                       },
                       {
                         "type": "ImportExpression",
@@ -108,7 +109,8 @@
                               "kind": "init"
                             }
                           ]
-                        }
+                        },
+                        "phase": null
                       }
                     ]
                   }

--- a/test/language/expressions/dynamic-import/import-attributes/2nd-param-with-value-abrupt.json
+++ b/test/language/expressions/dynamic-import/import-attributes/2nd-param-with-value-abrupt.json
@@ -137,7 +137,8 @@
                       "kind": "init"
                     }
                   ]
-                }
+                },
+                "phase": null
               },
               "property": {
                 "type": "Identifier",

--- a/test/language/expressions/dynamic-import/import-attributes/2nd-param-with-value-non-string.json
+++ b/test/language/expressions/dynamic-import/import-attributes/2nd-param-with-value-non-string.json
@@ -345,7 +345,8 @@
                                   "kind": "init"
                                 }
                               ]
-                            }
+                            },
+                            "phase": null
                           },
                           {
                             "type": "Literal",
@@ -430,7 +431,8 @@
                                   "kind": "init"
                                 }
                               ]
-                            }
+                            },
+                            "phase": null
                           },
                           {
                             "type": "Literal",
@@ -515,7 +517,8 @@
                                   "kind": "init"
                                 }
                               ]
-                            }
+                            },
+                            "phase": null
                           },
                           {
                             "type": "Literal",
@@ -600,7 +603,8 @@
                                   "kind": "init"
                                 }
                               ]
-                            }
+                            },
+                            "phase": null
                           },
                           {
                             "type": "Literal",
@@ -699,7 +703,8 @@
                                   "kind": "init"
                                 }
                               ]
-                            }
+                            },
+                            "phase": null
                           },
                           {
                             "type": "Literal",
@@ -785,7 +790,8 @@
                                   "kind": "init"
                                 }
                               ]
-                            }
+                            },
+                            "phase": null
                           },
                           {
                             "type": "Literal",
@@ -869,7 +875,8 @@
                                   "kind": "init"
                                 }
                               ]
-                            }
+                            },
+                            "phase": null
                           },
                           {
                             "type": "Literal",

--- a/test/language/expressions/dynamic-import/import-attributes/2nd-param-yield-expr.json
+++ b/test/language/expressions/dynamic-import/import-attributes/2nd-param-yield-expr.json
@@ -92,7 +92,8 @@
                             "end": 660,
                             "delegate": false,
                             "argument": null
-                          }
+                          },
+                          "phase": null
                         }
                       }
                     }

--- a/test/language/expressions/dynamic-import/import-attributes/2nd-param-yield-ident-valid.json
+++ b/test/language/expressions/dynamic-import/import-attributes/2nd-param-yield-ident-valid.json
@@ -59,7 +59,8 @@
                   "start": 633,
                   "end": 638,
                   "name": "yield"
-                }
+                },
+                "phase": null
               },
               "property": {
                 "type": "Identifier",

--- a/test/language/expressions/dynamic-import/import-attributes/trailing-comma-fulfill.json
+++ b/test/language/expressions/dynamic-import/import-attributes/trailing-comma-fulfill.json
@@ -34,7 +34,8 @@
                   "value": "./2nd-param_FIXTURE.js",
                   "raw": "'./2nd-param_FIXTURE.js'"
                 },
-                "options": null
+                "options": null,
+                "phase": null
               },
               "property": {
                 "type": "Identifier",

--- a/test/language/expressions/dynamic-import/import-attributes/trailing-comma-reject.json
+++ b/test/language/expressions/dynamic-import/import-attributes/trailing-comma-reject.json
@@ -108,7 +108,8 @@
                     }
                   ]
                 },
-                "options": null
+                "options": null,
+                "phase": null
               },
               "property": {
                 "type": "Identifier",

--- a/test/language/expressions/dynamic-import/imported-self-update.json
+++ b/test/language/expressions/dynamic-import/imported-self-update.json
@@ -122,7 +122,8 @@
                       "value": "./imported-self-update.js",
                       "raw": "'./imported-self-update.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   }
                 }
               }

--- a/test/language/expressions/dynamic-import/indirect-resolution.json
+++ b/test/language/expressions/dynamic-import/indirect-resolution.json
@@ -34,7 +34,8 @@
                   "value": "./indirect-resolution-1_FIXTURE.js",
                   "raw": "'./indirect-resolution-1_FIXTURE.js'"
                 },
-                "options": null
+                "options": null,
+                "phase": null
               },
               "property": {
                 "type": "Identifier",

--- a/test/language/expressions/dynamic-import/namespace/await-ns-Symbol-toStringTag.json
+++ b/test/language/expressions/dynamic-import/namespace/await-ns-Symbol-toStringTag.json
@@ -52,7 +52,8 @@
                       "value": "./module-code_FIXTURE.js",
                       "raw": "'./module-code_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   }
                 }
               }

--- a/test/language/expressions/dynamic-import/namespace/await-ns-define-own-property.json
+++ b/test/language/expressions/dynamic-import/namespace/await-ns-define-own-property.json
@@ -139,7 +139,8 @@
                       "value": "./define-own-property_FIXTURE.js",
                       "raw": "'./define-own-property_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   }
                 }
               }

--- a/test/language/expressions/dynamic-import/namespace/await-ns-delete-exported-init-no-strict.json
+++ b/test/language/expressions/dynamic-import/namespace/await-ns-delete-exported-init-no-strict.json
@@ -52,7 +52,8 @@
                       "value": "./module-code_FIXTURE.js",
                       "raw": "'./module-code_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   }
                 }
               }

--- a/test/language/expressions/dynamic-import/namespace/await-ns-delete-exported-init-strict.json
+++ b/test/language/expressions/dynamic-import/namespace/await-ns-delete-exported-init-strict.json
@@ -52,7 +52,8 @@
                       "value": "./module-code_FIXTURE.js",
                       "raw": "'./module-code_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   }
                 }
               }

--- a/test/language/expressions/dynamic-import/namespace/await-ns-delete-non-exported-no-strict.json
+++ b/test/language/expressions/dynamic-import/namespace/await-ns-delete-non-exported-no-strict.json
@@ -52,7 +52,8 @@
                       "value": "./empty_FIXTURE.js",
                       "raw": "'./empty_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   }
                 }
               }

--- a/test/language/expressions/dynamic-import/namespace/await-ns-delete-non-exported-strict.json
+++ b/test/language/expressions/dynamic-import/namespace/await-ns-delete-non-exported-strict.json
@@ -52,7 +52,8 @@
                       "value": "./empty_FIXTURE.js",
                       "raw": "'./empty_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   }
                 }
               }

--- a/test/language/expressions/dynamic-import/namespace/await-ns-extensible.json
+++ b/test/language/expressions/dynamic-import/namespace/await-ns-extensible.json
@@ -52,7 +52,8 @@
                       "value": "./module-code_FIXTURE.js",
                       "raw": "'./module-code_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   }
                 }
               }

--- a/test/language/expressions/dynamic-import/namespace/await-ns-get-nested-namespace-dflt-direct.json
+++ b/test/language/expressions/dynamic-import/namespace/await-ns-get-nested-namespace-dflt-direct.json
@@ -52,7 +52,8 @@
                       "value": "./get-nested-namespace-dflt-skip-prod_FIXTURE.js",
                       "raw": "'./get-nested-namespace-dflt-skip-prod_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   }
                 }
               }

--- a/test/language/expressions/dynamic-import/namespace/await-ns-get-nested-namespace-dflt-indirect.json
+++ b/test/language/expressions/dynamic-import/namespace/await-ns-get-nested-namespace-dflt-indirect.json
@@ -52,7 +52,8 @@
                       "value": "./get-nested-namespace-dflt-skip-named_FIXTURE.js",
                       "raw": "'./get-nested-namespace-dflt-skip-named_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   }
                 }
               }

--- a/test/language/expressions/dynamic-import/namespace/await-ns-get-nested-namespace-props-nrml.json
+++ b/test/language/expressions/dynamic-import/namespace/await-ns-get-nested-namespace-props-nrml.json
@@ -157,7 +157,8 @@
                       "value": "./get-nested-namespace-props-nrml-1_FIXTURE.js",
                       "raw": "'./get-nested-namespace-props-nrml-1_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   }
                 }
               }

--- a/test/language/expressions/dynamic-import/namespace/await-ns-get-own-property-str-found-init.json
+++ b/test/language/expressions/dynamic-import/namespace/await-ns-get-own-property-str-found-init.json
@@ -52,7 +52,8 @@
                       "value": "./module-code_FIXTURE.js",
                       "raw": "'./module-code_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   }
                 }
               }

--- a/test/language/expressions/dynamic-import/namespace/await-ns-get-own-property-str-not-found.json
+++ b/test/language/expressions/dynamic-import/namespace/await-ns-get-own-property-str-not-found.json
@@ -52,7 +52,8 @@
                       "value": "./module-code_FIXTURE.js",
                       "raw": "'./module-code_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   }
                 }
               }

--- a/test/language/expressions/dynamic-import/namespace/await-ns-get-own-property-sym.json
+++ b/test/language/expressions/dynamic-import/namespace/await-ns-get-own-property-sym.json
@@ -92,7 +92,8 @@
                       "value": "./module-code_FIXTURE.js",
                       "raw": "'./module-code_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   }
                 }
               }

--- a/test/language/expressions/dynamic-import/namespace/await-ns-get-str-found.json
+++ b/test/language/expressions/dynamic-import/namespace/await-ns-get-str-found.json
@@ -52,7 +52,8 @@
                       "value": "./module-code_FIXTURE.js",
                       "raw": "'./module-code_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   }
                 }
               }

--- a/test/language/expressions/dynamic-import/namespace/await-ns-get-str-not-found.json
+++ b/test/language/expressions/dynamic-import/namespace/await-ns-get-str-not-found.json
@@ -72,7 +72,8 @@
                       "value": "./module-code_FIXTURE.js",
                       "raw": "'./module-code_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   }
                 }
               }

--- a/test/language/expressions/dynamic-import/namespace/await-ns-get-sym-found.json
+++ b/test/language/expressions/dynamic-import/namespace/await-ns-get-sym-found.json
@@ -52,7 +52,8 @@
                       "value": "./module-code_FIXTURE.js",
                       "raw": "'./module-code_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   }
                 }
               }

--- a/test/language/expressions/dynamic-import/namespace/await-ns-get-sym-not-found.json
+++ b/test/language/expressions/dynamic-import/namespace/await-ns-get-sym-not-found.json
@@ -52,7 +52,8 @@
                       "value": "./module-code_FIXTURE.js",
                       "raw": "'./module-code_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   }
                 }
               }

--- a/test/language/expressions/dynamic-import/namespace/await-ns-has-property-str-found-init.json
+++ b/test/language/expressions/dynamic-import/namespace/await-ns-has-property-str-found-init.json
@@ -52,7 +52,8 @@
                       "value": "./module-code_FIXTURE.js",
                       "raw": "'./module-code_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   }
                 }
               }

--- a/test/language/expressions/dynamic-import/namespace/await-ns-has-property-str-not-found.json
+++ b/test/language/expressions/dynamic-import/namespace/await-ns-has-property-str-not-found.json
@@ -72,7 +72,8 @@
                       "value": "./module-code_FIXTURE.js",
                       "raw": "'./module-code_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   }
                 }
               }

--- a/test/language/expressions/dynamic-import/namespace/await-ns-has-property-sym-found.json
+++ b/test/language/expressions/dynamic-import/namespace/await-ns-has-property-sym-found.json
@@ -52,7 +52,8 @@
                       "value": "./module-code_FIXTURE.js",
                       "raw": "'./module-code_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   }
                 }
               }

--- a/test/language/expressions/dynamic-import/namespace/await-ns-has-property-sym-not-found.json
+++ b/test/language/expressions/dynamic-import/namespace/await-ns-has-property-sym-not-found.json
@@ -92,7 +92,8 @@
                       "value": "./module-code_FIXTURE.js",
                       "raw": "'./module-code_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   }
                 }
               }

--- a/test/language/expressions/dynamic-import/namespace/await-ns-no-iterator.json
+++ b/test/language/expressions/dynamic-import/namespace/await-ns-no-iterator.json
@@ -52,7 +52,8 @@
                       "value": "./module-code_FIXTURE.js",
                       "raw": "'./module-code_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   }
                 }
               }

--- a/test/language/expressions/dynamic-import/namespace/await-ns-own-property-keys-sort.json
+++ b/test/language/expressions/dynamic-import/namespace/await-ns-own-property-keys-sort.json
@@ -52,7 +52,8 @@
                       "value": "./own-keys-sort_FIXTURE.js",
                       "raw": "'./own-keys-sort_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   }
                 }
               }

--- a/test/language/expressions/dynamic-import/namespace/await-ns-prevent-extensions-object.json
+++ b/test/language/expressions/dynamic-import/namespace/await-ns-prevent-extensions-object.json
@@ -52,7 +52,8 @@
                       "value": "./empty_FIXTURE.js",
                       "raw": "'./empty_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   }
                 }
               }

--- a/test/language/expressions/dynamic-import/namespace/await-ns-prevent-extensions-reflect.json
+++ b/test/language/expressions/dynamic-import/namespace/await-ns-prevent-extensions-reflect.json
@@ -52,7 +52,8 @@
                       "value": "./empty_FIXTURE.js",
                       "raw": "'./empty_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   }
                 }
               }

--- a/test/language/expressions/dynamic-import/namespace/await-ns-prop-descs.json
+++ b/test/language/expressions/dynamic-import/namespace/await-ns-prop-descs.json
@@ -52,7 +52,8 @@
                       "value": "./module-code_FIXTURE.js",
                       "raw": "'./module-code_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   }
                 }
               }

--- a/test/language/expressions/dynamic-import/namespace/await-ns-prototype.json
+++ b/test/language/expressions/dynamic-import/namespace/await-ns-prototype.json
@@ -52,7 +52,8 @@
                       "value": "./module-code_FIXTURE.js",
                       "raw": "'./module-code_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   }
                 }
               }

--- a/test/language/expressions/dynamic-import/namespace/await-ns-set-no-strict.json
+++ b/test/language/expressions/dynamic-import/namespace/await-ns-set-no-strict.json
@@ -92,7 +92,8 @@
                       "value": "./module-code_FIXTURE.js",
                       "raw": "'./module-code_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   }
                 }
               }

--- a/test/language/expressions/dynamic-import/namespace/await-ns-set-prototype-of-null.json
+++ b/test/language/expressions/dynamic-import/namespace/await-ns-set-prototype-of-null.json
@@ -52,7 +52,8 @@
                       "value": "./empty_FIXTURE.js",
                       "raw": "'./empty_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   }
                 }
               }

--- a/test/language/expressions/dynamic-import/namespace/await-ns-set-prototype-of.json
+++ b/test/language/expressions/dynamic-import/namespace/await-ns-set-prototype-of.json
@@ -52,7 +52,8 @@
                       "value": "./module-code_FIXTURE.js",
                       "raw": "'./module-code_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   }
                 }
               }

--- a/test/language/expressions/dynamic-import/namespace/await-ns-set-same-values-no-strict.json
+++ b/test/language/expressions/dynamic-import/namespace/await-ns-set-same-values-no-strict.json
@@ -52,7 +52,8 @@
                       "value": "./module-code_FIXTURE.js",
                       "raw": "'./module-code_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   }
                 }
               }

--- a/test/language/expressions/dynamic-import/namespace/await-ns-set-same-values-strict.json
+++ b/test/language/expressions/dynamic-import/namespace/await-ns-set-same-values-strict.json
@@ -52,7 +52,8 @@
                       "value": "./module-code_FIXTURE.js",
                       "raw": "'./module-code_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   }
                 }
               }

--- a/test/language/expressions/dynamic-import/namespace/await-ns-set-strict.json
+++ b/test/language/expressions/dynamic-import/namespace/await-ns-set-strict.json
@@ -92,7 +92,8 @@
                       "value": "./module-code_FIXTURE.js",
                       "raw": "'./module-code_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   }
                 }
               }

--- a/test/language/expressions/dynamic-import/namespace/default-property-not-set-own.json
+++ b/test/language/expressions/dynamic-import/namespace/default-property-not-set-own.json
@@ -42,7 +42,8 @@
                       "value": "./empty_FIXTURE.js",
                       "raw": "'./empty_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   },
                   "property": {
                     "type": "Identifier",

--- a/test/language/expressions/dynamic-import/namespace/promise-then-ns-Symbol-toStringTag.json
+++ b/test/language/expressions/dynamic-import/namespace/promise-then-ns-Symbol-toStringTag.json
@@ -42,7 +42,8 @@
                       "value": "./module-code_FIXTURE.js",
                       "raw": "'./module-code_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   },
                   "property": {
                     "type": "Identifier",

--- a/test/language/expressions/dynamic-import/namespace/promise-then-ns-define-own-property.json
+++ b/test/language/expressions/dynamic-import/namespace/promise-then-ns-define-own-property.json
@@ -129,7 +129,8 @@
                       "value": "./define-own-property_FIXTURE.js",
                       "raw": "'./define-own-property_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   },
                   "property": {
                     "type": "Identifier",

--- a/test/language/expressions/dynamic-import/namespace/promise-then-ns-delete-exported-init-no-strict.json
+++ b/test/language/expressions/dynamic-import/namespace/promise-then-ns-delete-exported-init-no-strict.json
@@ -42,7 +42,8 @@
                       "value": "./module-code_FIXTURE.js",
                       "raw": "'./module-code_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   },
                   "property": {
                     "type": "Identifier",

--- a/test/language/expressions/dynamic-import/namespace/promise-then-ns-delete-exported-init-strict.json
+++ b/test/language/expressions/dynamic-import/namespace/promise-then-ns-delete-exported-init-strict.json
@@ -42,7 +42,8 @@
                       "value": "./module-code_FIXTURE.js",
                       "raw": "'./module-code_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   },
                   "property": {
                     "type": "Identifier",

--- a/test/language/expressions/dynamic-import/namespace/promise-then-ns-delete-non-exported-no-strict.json
+++ b/test/language/expressions/dynamic-import/namespace/promise-then-ns-delete-non-exported-no-strict.json
@@ -42,7 +42,8 @@
                       "value": "./empty_FIXTURE.js",
                       "raw": "'./empty_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   },
                   "property": {
                     "type": "Identifier",

--- a/test/language/expressions/dynamic-import/namespace/promise-then-ns-delete-non-exported-strict.json
+++ b/test/language/expressions/dynamic-import/namespace/promise-then-ns-delete-non-exported-strict.json
@@ -42,7 +42,8 @@
                       "value": "./empty_FIXTURE.js",
                       "raw": "'./empty_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   },
                   "property": {
                     "type": "Identifier",

--- a/test/language/expressions/dynamic-import/namespace/promise-then-ns-extensible.json
+++ b/test/language/expressions/dynamic-import/namespace/promise-then-ns-extensible.json
@@ -42,7 +42,8 @@
                       "value": "./module-code_FIXTURE.js",
                       "raw": "'./module-code_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   },
                   "property": {
                     "type": "Identifier",

--- a/test/language/expressions/dynamic-import/namespace/promise-then-ns-get-nested-namespace-dflt-direct.json
+++ b/test/language/expressions/dynamic-import/namespace/promise-then-ns-get-nested-namespace-dflt-direct.json
@@ -42,7 +42,8 @@
                       "value": "./get-nested-namespace-dflt-skip-prod_FIXTURE.js",
                       "raw": "'./get-nested-namespace-dflt-skip-prod_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   },
                   "property": {
                     "type": "Identifier",

--- a/test/language/expressions/dynamic-import/namespace/promise-then-ns-get-nested-namespace-dflt-indirect.json
+++ b/test/language/expressions/dynamic-import/namespace/promise-then-ns-get-nested-namespace-dflt-indirect.json
@@ -42,7 +42,8 @@
                       "value": "./get-nested-namespace-dflt-skip-named_FIXTURE.js",
                       "raw": "'./get-nested-namespace-dflt-skip-named_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   },
                   "property": {
                     "type": "Identifier",

--- a/test/language/expressions/dynamic-import/namespace/promise-then-ns-get-nested-namespace-props-nrml.json
+++ b/test/language/expressions/dynamic-import/namespace/promise-then-ns-get-nested-namespace-props-nrml.json
@@ -147,7 +147,8 @@
                       "value": "./get-nested-namespace-props-nrml-1_FIXTURE.js",
                       "raw": "'./get-nested-namespace-props-nrml-1_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   },
                   "property": {
                     "type": "Identifier",

--- a/test/language/expressions/dynamic-import/namespace/promise-then-ns-get-own-property-str-found-init.json
+++ b/test/language/expressions/dynamic-import/namespace/promise-then-ns-get-own-property-str-found-init.json
@@ -42,7 +42,8 @@
                       "value": "./module-code_FIXTURE.js",
                       "raw": "'./module-code_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   },
                   "property": {
                     "type": "Identifier",

--- a/test/language/expressions/dynamic-import/namespace/promise-then-ns-get-own-property-str-not-found.json
+++ b/test/language/expressions/dynamic-import/namespace/promise-then-ns-get-own-property-str-not-found.json
@@ -42,7 +42,8 @@
                       "value": "./module-code_FIXTURE.js",
                       "raw": "'./module-code_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   },
                   "property": {
                     "type": "Identifier",

--- a/test/language/expressions/dynamic-import/namespace/promise-then-ns-get-own-property-sym.json
+++ b/test/language/expressions/dynamic-import/namespace/promise-then-ns-get-own-property-sym.json
@@ -82,7 +82,8 @@
                       "value": "./module-code_FIXTURE.js",
                       "raw": "'./module-code_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   },
                   "property": {
                     "type": "Identifier",

--- a/test/language/expressions/dynamic-import/namespace/promise-then-ns-get-str-found.json
+++ b/test/language/expressions/dynamic-import/namespace/promise-then-ns-get-str-found.json
@@ -42,7 +42,8 @@
                       "value": "./module-code_FIXTURE.js",
                       "raw": "'./module-code_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   },
                   "property": {
                     "type": "Identifier",

--- a/test/language/expressions/dynamic-import/namespace/promise-then-ns-get-str-not-found.json
+++ b/test/language/expressions/dynamic-import/namespace/promise-then-ns-get-str-not-found.json
@@ -62,7 +62,8 @@
                       "value": "./module-code_FIXTURE.js",
                       "raw": "'./module-code_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   },
                   "property": {
                     "type": "Identifier",

--- a/test/language/expressions/dynamic-import/namespace/promise-then-ns-get-sym-found.json
+++ b/test/language/expressions/dynamic-import/namespace/promise-then-ns-get-sym-found.json
@@ -42,7 +42,8 @@
                       "value": "./module-code_FIXTURE.js",
                       "raw": "'./module-code_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   },
                   "property": {
                     "type": "Identifier",

--- a/test/language/expressions/dynamic-import/namespace/promise-then-ns-get-sym-not-found.json
+++ b/test/language/expressions/dynamic-import/namespace/promise-then-ns-get-sym-not-found.json
@@ -42,7 +42,8 @@
                       "value": "./module-code_FIXTURE.js",
                       "raw": "'./module-code_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   },
                   "property": {
                     "type": "Identifier",

--- a/test/language/expressions/dynamic-import/namespace/promise-then-ns-has-property-str-found-init.json
+++ b/test/language/expressions/dynamic-import/namespace/promise-then-ns-has-property-str-found-init.json
@@ -42,7 +42,8 @@
                       "value": "./module-code_FIXTURE.js",
                       "raw": "'./module-code_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   },
                   "property": {
                     "type": "Identifier",

--- a/test/language/expressions/dynamic-import/namespace/promise-then-ns-has-property-str-not-found.json
+++ b/test/language/expressions/dynamic-import/namespace/promise-then-ns-has-property-str-not-found.json
@@ -62,7 +62,8 @@
                       "value": "./module-code_FIXTURE.js",
                       "raw": "'./module-code_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   },
                   "property": {
                     "type": "Identifier",

--- a/test/language/expressions/dynamic-import/namespace/promise-then-ns-has-property-sym-found.json
+++ b/test/language/expressions/dynamic-import/namespace/promise-then-ns-has-property-sym-found.json
@@ -42,7 +42,8 @@
                       "value": "./module-code_FIXTURE.js",
                       "raw": "'./module-code_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   },
                   "property": {
                     "type": "Identifier",

--- a/test/language/expressions/dynamic-import/namespace/promise-then-ns-has-property-sym-not-found.json
+++ b/test/language/expressions/dynamic-import/namespace/promise-then-ns-has-property-sym-not-found.json
@@ -82,7 +82,8 @@
                       "value": "./module-code_FIXTURE.js",
                       "raw": "'./module-code_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   },
                   "property": {
                     "type": "Identifier",

--- a/test/language/expressions/dynamic-import/namespace/promise-then-ns-no-iterator.json
+++ b/test/language/expressions/dynamic-import/namespace/promise-then-ns-no-iterator.json
@@ -42,7 +42,8 @@
                       "value": "./module-code_FIXTURE.js",
                       "raw": "'./module-code_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   },
                   "property": {
                     "type": "Identifier",

--- a/test/language/expressions/dynamic-import/namespace/promise-then-ns-own-property-keys-sort.json
+++ b/test/language/expressions/dynamic-import/namespace/promise-then-ns-own-property-keys-sort.json
@@ -42,7 +42,8 @@
                       "value": "./own-keys-sort_FIXTURE.js",
                       "raw": "'./own-keys-sort_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   },
                   "property": {
                     "type": "Identifier",

--- a/test/language/expressions/dynamic-import/namespace/promise-then-ns-prevent-extensions-object.json
+++ b/test/language/expressions/dynamic-import/namespace/promise-then-ns-prevent-extensions-object.json
@@ -42,7 +42,8 @@
                       "value": "./empty_FIXTURE.js",
                       "raw": "'./empty_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   },
                   "property": {
                     "type": "Identifier",

--- a/test/language/expressions/dynamic-import/namespace/promise-then-ns-prevent-extensions-reflect.json
+++ b/test/language/expressions/dynamic-import/namespace/promise-then-ns-prevent-extensions-reflect.json
@@ -42,7 +42,8 @@
                       "value": "./empty_FIXTURE.js",
                       "raw": "'./empty_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   },
                   "property": {
                     "type": "Identifier",

--- a/test/language/expressions/dynamic-import/namespace/promise-then-ns-prop-descs.json
+++ b/test/language/expressions/dynamic-import/namespace/promise-then-ns-prop-descs.json
@@ -42,7 +42,8 @@
                       "value": "./module-code_FIXTURE.js",
                       "raw": "'./module-code_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   },
                   "property": {
                     "type": "Identifier",

--- a/test/language/expressions/dynamic-import/namespace/promise-then-ns-prototype.json
+++ b/test/language/expressions/dynamic-import/namespace/promise-then-ns-prototype.json
@@ -42,7 +42,8 @@
                       "value": "./module-code_FIXTURE.js",
                       "raw": "'./module-code_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   },
                   "property": {
                     "type": "Identifier",

--- a/test/language/expressions/dynamic-import/namespace/promise-then-ns-set-no-strict.json
+++ b/test/language/expressions/dynamic-import/namespace/promise-then-ns-set-no-strict.json
@@ -82,7 +82,8 @@
                       "value": "./module-code_FIXTURE.js",
                       "raw": "'./module-code_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   },
                   "property": {
                     "type": "Identifier",

--- a/test/language/expressions/dynamic-import/namespace/promise-then-ns-set-prototype-of-null.json
+++ b/test/language/expressions/dynamic-import/namespace/promise-then-ns-set-prototype-of-null.json
@@ -42,7 +42,8 @@
                       "value": "./empty_FIXTURE.js",
                       "raw": "'./empty_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   },
                   "property": {
                     "type": "Identifier",

--- a/test/language/expressions/dynamic-import/namespace/promise-then-ns-set-prototype-of.json
+++ b/test/language/expressions/dynamic-import/namespace/promise-then-ns-set-prototype-of.json
@@ -42,7 +42,8 @@
                       "value": "./module-code_FIXTURE.js",
                       "raw": "'./module-code_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   },
                   "property": {
                     "type": "Identifier",

--- a/test/language/expressions/dynamic-import/namespace/promise-then-ns-set-same-values-no-strict.json
+++ b/test/language/expressions/dynamic-import/namespace/promise-then-ns-set-same-values-no-strict.json
@@ -42,7 +42,8 @@
                       "value": "./module-code_FIXTURE.js",
                       "raw": "'./module-code_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   },
                   "property": {
                     "type": "Identifier",

--- a/test/language/expressions/dynamic-import/namespace/promise-then-ns-set-same-values-strict.json
+++ b/test/language/expressions/dynamic-import/namespace/promise-then-ns-set-same-values-strict.json
@@ -42,7 +42,8 @@
                       "value": "./module-code_FIXTURE.js",
                       "raw": "'./module-code_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   },
                   "property": {
                     "type": "Identifier",

--- a/test/language/expressions/dynamic-import/namespace/promise-then-ns-set-strict.json
+++ b/test/language/expressions/dynamic-import/namespace/promise-then-ns-set-strict.json
@@ -82,7 +82,8 @@
                       "value": "./module-code_FIXTURE.js",
                       "raw": "'./module-code_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   },
                   "property": {
                     "type": "Identifier",

--- a/test/language/expressions/dynamic-import/returns-promise.json
+++ b/test/language/expressions/dynamic-import/returns-promise.json
@@ -120,7 +120,8 @@
               "value": "./dynamic-import-module_FIXTURE.js",
               "raw": "'./dynamic-import-module_FIXTURE.js'"
             },
-            "options": null
+            "options": null,
+            "phase": null
           }
         }
       ],

--- a/test/language/expressions/dynamic-import/reuse-namespace-object-from-import.json
+++ b/test/language/expressions/dynamic-import/reuse-namespace-object-from-import.json
@@ -90,7 +90,8 @@
                           "value": "./module-code_FIXTURE.js",
                           "raw": "'./module-code_FIXTURE.js'"
                         },
-                        "options": null
+                        "options": null,
+                        "phase": null
                       },
                       {
                         "type": "ImportExpression",
@@ -103,7 +104,8 @@
                           "value": "./module-code_FIXTURE.js",
                           "raw": "'./module-code_FIXTURE.js'"
                         },
-                        "options": null
+                        "options": null,
+                        "phase": null
                       }
                     ]
                   }

--- a/test/language/expressions/dynamic-import/reuse-namespace-object-from-script.json
+++ b/test/language/expressions/dynamic-import/reuse-namespace-object-from-script.json
@@ -63,7 +63,8 @@
                           "value": "./empty_FIXTURE.js",
                           "raw": "'./empty_FIXTURE.js'"
                         },
-                        "options": null
+                        "options": null,
+                        "phase": null
                       },
                       {
                         "type": "ImportExpression",
@@ -76,7 +77,8 @@
                           "value": "./empty_FIXTURE.js",
                           "raw": "'./empty_FIXTURE.js'"
                         },
-                        "options": null
+                        "options": null,
+                        "phase": null
                       }
                     ]
                   }

--- a/test/language/expressions/dynamic-import/reuse-namespace-object.json
+++ b/test/language/expressions/dynamic-import/reuse-namespace-object.json
@@ -63,7 +63,8 @@
                           "value": "./dynamic-import-module_FIXTURE.js",
                           "raw": "'./dynamic-import-module_FIXTURE.js'"
                         },
-                        "options": null
+                        "options": null,
+                        "phase": null
                       },
                       {
                         "type": "ImportExpression",
@@ -76,7 +77,8 @@
                           "value": "./dynamic-import-module_FIXTURE.js",
                           "raw": "'./dynamic-import-module_FIXTURE.js'"
                         },
-                        "options": null
+                        "options": null,
+                        "phase": null
                       }
                     ]
                   }

--- a/test/language/expressions/dynamic-import/syntax/valid/callexpression-arguments.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/callexpression-arguments.json
@@ -70,7 +70,8 @@
                         "value": "./empty_FIXTURE.js",
                         "raw": "'./empty_FIXTURE.js'"
                       },
-                      "options": null
+                      "options": null,
+                      "phase": null
                     },
                     "arguments": [],
                     "optional": false
@@ -157,7 +158,8 @@
                         "value": "./empty_FIXTURE.js",
                         "raw": "'./empty_FIXTURE.js'"
                       },
-                      "options": null
+                      "options": null,
+                      "phase": null
                     },
                     "arguments": [
                       {
@@ -252,7 +254,8 @@
                         "value": "./empty_FIXTURE.js",
                         "raw": "'./empty_FIXTURE.js'"
                       },
-                      "options": null
+                      "options": null,
+                      "phase": null
                     },
                     "arguments": [
                       {
@@ -354,7 +357,8 @@
                         "value": "./empty_FIXTURE.js",
                         "raw": "'./empty_FIXTURE.js'"
                       },
-                      "options": null
+                      "options": null,
+                      "phase": null
                     },
                     "arguments": [
                       {

--- a/test/language/expressions/dynamic-import/syntax/valid/callexpression-templateliteral.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/callexpression-templateliteral.json
@@ -70,7 +70,8 @@
                         "value": "./empty_FIXTURE.js",
                         "raw": "'./empty_FIXTURE.js'"
                       },
-                      "options": null
+                      "options": null,
+                      "phase": null
                     },
                     "quasi": {
                       "type": "TemplateLiteral",
@@ -166,7 +167,8 @@
                         "value": "./empty_FIXTURE.js",
                         "raw": "'./empty_FIXTURE.js'"
                       },
-                      "options": null
+                      "options": null,
+                      "phase": null
                     },
                     "quasi": {
                       "type": "TemplateLiteral",
@@ -262,7 +264,8 @@
                         "value": "./empty_FIXTURE.js",
                         "raw": "'./empty_FIXTURE.js'"
                       },
-                      "options": null
+                      "options": null,
+                      "phase": null
                     },
                     "quasi": {
                       "type": "TemplateLiteral",

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-arrow-assignment-expression-empty-str-is-valid-assign-expr.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-arrow-assignment-expression-empty-str-is-valid-assign-expr.json
@@ -38,7 +38,8 @@
                 "value": "",
                 "raw": "''"
               },
-              "options": null
+              "options": null,
+              "phase": null
             }
           }
         }

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-arrow-assignment-expression-import-attributes-trailing-comma-first.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-arrow-assignment-expression-import-attributes-trailing-comma-first.json
@@ -38,7 +38,8 @@
                 "value": "./empty_FIXTURE.js",
                 "raw": "'./empty_FIXTURE.js'"
               },
-              "options": null
+              "options": null,
+              "phase": null
             }
           }
         }

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-arrow-assignment-expression-import-attributes-trailing-comma-second.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-arrow-assignment-expression-import-attributes-trailing-comma-second.json
@@ -43,7 +43,8 @@
                 "start": 1353,
                 "end": 1355,
                 "properties": []
-              }
+              },
+              "phase": null
             }
           }
         }

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-arrow-assignment-expression-nested-imports.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-arrow-assignment-expression-nested-imports.json
@@ -46,11 +46,14 @@
                     "value": "./empty_FIXTURE.js",
                     "raw": "'./empty_FIXTURE.js'"
                   },
-                  "options": null
+                  "options": null,
+                  "phase": null
                 },
-                "options": null
+                "options": null,
+                "phase": null
               },
-              "options": null
+              "options": null,
+              "phase": null
             }
           }
         }

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-arrow-assignment-expression-script-code-valid.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-arrow-assignment-expression-script-code-valid.json
@@ -79,7 +79,8 @@
                 "value": "./empty_FIXTURE.js",
                 "raw": "'./empty_FIXTURE.js'"
               },
-              "options": null
+              "options": null,
+              "phase": null
             }
           }
         }

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-arrow-empty-str-is-valid-assign-expr.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-arrow-empty-str-is-valid-assign-expr.json
@@ -47,7 +47,8 @@
                       "value": "",
                       "raw": "''"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   }
                 }
               ]

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-arrow-import-attributes-trailing-comma-first.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-arrow-import-attributes-trailing-comma-first.json
@@ -47,7 +47,8 @@
                       "value": "./empty_FIXTURE.js",
                       "raw": "'./empty_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   }
                 }
               ]

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-arrow-import-attributes-trailing-comma-second.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-arrow-import-attributes-trailing-comma-second.json
@@ -52,7 +52,8 @@
                       "start": 1335,
                       "end": 1337,
                       "properties": []
-                    }
+                    },
+                    "phase": null
                   }
                 }
               ]

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-arrow-nested-imports.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-arrow-nested-imports.json
@@ -55,11 +55,14 @@
                           "value": "./empty_FIXTURE.js",
                           "raw": "'./empty_FIXTURE.js'"
                         },
-                        "options": null
+                        "options": null,
+                        "phase": null
                       },
-                      "options": null
+                      "options": null,
+                      "phase": null
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   }
                 }
               ]

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-arrow-script-code-valid.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-arrow-script-code-valid.json
@@ -88,7 +88,8 @@
                       "value": "./empty_FIXTURE.js",
                       "raw": "'./empty_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   }
                 }
               ]

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-async-arrow-function-await-empty-str-is-valid-assign-expr.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-async-arrow-function-await-empty-str-is-valid-assign-expr.json
@@ -44,7 +44,8 @@
                       "value": "",
                       "raw": "''"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   }
                 }
               }

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-async-arrow-function-await-import-attributes-trailing-comma-first.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-async-arrow-function-await-import-attributes-trailing-comma-first.json
@@ -44,7 +44,8 @@
                       "value": "./empty_FIXTURE.js",
                       "raw": "'./empty_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   }
                 }
               }

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-async-arrow-function-await-import-attributes-trailing-comma-second.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-async-arrow-function-await-import-attributes-trailing-comma-second.json
@@ -49,7 +49,8 @@
                       "start": 1366,
                       "end": 1368,
                       "properties": []
-                    }
+                    },
+                    "phase": null
                   }
                 }
               }

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-async-arrow-function-await-nested-imports.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-async-arrow-function-await-nested-imports.json
@@ -52,11 +52,14 @@
                           "value": "./empty_FIXTURE.js",
                           "raw": "'./empty_FIXTURE.js'"
                         },
-                        "options": null
+                        "options": null,
+                        "phase": null
                       },
-                      "options": null
+                      "options": null,
+                      "phase": null
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   }
                 }
               }

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-async-arrow-function-await-script-code-valid.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-async-arrow-function-await-script-code-valid.json
@@ -85,7 +85,8 @@
                       "value": "./empty_FIXTURE.js",
                       "raw": "'./empty_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   }
                 }
               }

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-async-arrow-function-return-await-empty-str-is-valid-assign-expr.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-async-arrow-function-return-await-empty-str-is-valid-assign-expr.json
@@ -35,7 +35,8 @@
                 "value": "",
                 "raw": "''"
               },
-              "options": null
+              "options": null,
+              "phase": null
             }
           }
         }

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-async-arrow-function-return-await-import-attributes-trailing-comma-first.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-async-arrow-function-return-await-import-attributes-trailing-comma-first.json
@@ -35,7 +35,8 @@
                 "value": "./empty_FIXTURE.js",
                 "raw": "'./empty_FIXTURE.js'"
               },
-              "options": null
+              "options": null,
+              "phase": null
             }
           }
         }

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-async-arrow-function-return-await-import-attributes-trailing-comma-second.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-async-arrow-function-return-await-import-attributes-trailing-comma-second.json
@@ -40,7 +40,8 @@
                 "start": 1379,
                 "end": 1381,
                 "properties": []
-              }
+              },
+              "phase": null
             }
           }
         }

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-async-arrow-function-return-await-nested-imports.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-async-arrow-function-return-await-nested-imports.json
@@ -43,11 +43,14 @@
                     "value": "./empty_FIXTURE.js",
                     "raw": "'./empty_FIXTURE.js'"
                   },
-                  "options": null
+                  "options": null,
+                  "phase": null
                 },
-                "options": null
+                "options": null,
+                "phase": null
               },
-              "options": null
+              "options": null,
+              "phase": null
             }
           }
         }

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-async-arrow-function-return-await-script-code-valid.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-async-arrow-function-return-await-script-code-valid.json
@@ -76,7 +76,8 @@
                 "value": "./empty_FIXTURE.js",
                 "raw": "'./empty_FIXTURE.js'"
               },
-              "options": null
+              "options": null,
+              "phase": null
             }
           }
         }

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-async-function-await-empty-str-is-valid-assign-expr.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-async-function-await-empty-str-is-valid-assign-expr.json
@@ -41,7 +41,8 @@
                   "value": "",
                   "raw": "''"
                 },
-                "options": null
+                "options": null,
+                "phase": null
               }
             }
           }

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-async-function-await-import-attributes-trailing-comma-first.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-async-function-await-import-attributes-trailing-comma-first.json
@@ -41,7 +41,8 @@
                   "value": "./empty_FIXTURE.js",
                   "raw": "'./empty_FIXTURE.js'"
                 },
-                "options": null
+                "options": null,
+                "phase": null
               }
             }
           }

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-async-function-await-import-attributes-trailing-comma-second.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-async-function-await-import-attributes-trailing-comma-second.json
@@ -46,7 +46,8 @@
                   "start": 1361,
                   "end": 1363,
                   "properties": []
-                }
+                },
+                "phase": null
               }
             }
           }

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-async-function-await-nested-imports.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-async-function-await-nested-imports.json
@@ -49,11 +49,14 @@
                       "value": "./empty_FIXTURE.js",
                       "raw": "'./empty_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   },
-                  "options": null
+                  "options": null,
+                  "phase": null
                 },
-                "options": null
+                "options": null,
+                "phase": null
               }
             }
           }

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-async-function-await-script-code-valid.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-async-function-await-script-code-valid.json
@@ -82,7 +82,8 @@
                   "value": "./empty_FIXTURE.js",
                   "raw": "'./empty_FIXTURE.js'"
                 },
-                "options": null
+                "options": null,
+                "phase": null
               }
             }
           }

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-async-function-empty-str-is-valid-assign-expr.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-async-function-empty-str-is-valid-assign-expr.json
@@ -37,7 +37,8 @@
                 "value": "",
                 "raw": "''"
               },
-              "options": null
+              "options": null,
+              "phase": null
             }
           }
         ]

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-async-function-import-attributes-trailing-comma-first.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-async-function-import-attributes-trailing-comma-first.json
@@ -37,7 +37,8 @@
                 "value": "./empty_FIXTURE.js",
                 "raw": "'./empty_FIXTURE.js'"
               },
-              "options": null
+              "options": null,
+              "phase": null
             }
           }
         ]

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-async-function-import-attributes-trailing-comma-second.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-async-function-import-attributes-trailing-comma-second.json
@@ -42,7 +42,8 @@
                 "start": 1349,
                 "end": 1351,
                 "properties": []
-              }
+              },
+              "phase": null
             }
           }
         ]

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-async-function-nested-imports.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-async-function-nested-imports.json
@@ -45,11 +45,14 @@
                     "value": "./empty_FIXTURE.js",
                     "raw": "'./empty_FIXTURE.js'"
                   },
-                  "options": null
+                  "options": null,
+                  "phase": null
                 },
-                "options": null
+                "options": null,
+                "phase": null
               },
-              "options": null
+              "options": null,
+              "phase": null
             }
           }
         ]

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-async-function-return-await-empty-str-is-valid-assign-expr.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-async-function-return-await-empty-str-is-valid-assign-expr.json
@@ -41,7 +41,8 @@
                   "value": "",
                   "raw": "''"
                 },
-                "options": null
+                "options": null,
+                "phase": null
               }
             }
           }

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-async-function-return-await-import-attributes-trailing-comma-first.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-async-function-return-await-import-attributes-trailing-comma-first.json
@@ -41,7 +41,8 @@
                   "value": "./empty_FIXTURE.js",
                   "raw": "'./empty_FIXTURE.js'"
                 },
-                "options": null
+                "options": null,
+                "phase": null
               }
             }
           }

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-async-function-return-await-import-attributes-trailing-comma-second.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-async-function-return-await-import-attributes-trailing-comma-second.json
@@ -46,7 +46,8 @@
                   "start": 1375,
                   "end": 1377,
                   "properties": []
-                }
+                },
+                "phase": null
               }
             }
           }

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-async-function-return-await-nested-imports.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-async-function-return-await-nested-imports.json
@@ -49,11 +49,14 @@
                       "value": "./empty_FIXTURE.js",
                       "raw": "'./empty_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   },
-                  "options": null
+                  "options": null,
+                  "phase": null
                 },
-                "options": null
+                "options": null,
+                "phase": null
               }
             }
           }

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-async-function-return-await-script-code-valid.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-async-function-return-await-script-code-valid.json
@@ -82,7 +82,8 @@
                   "value": "./empty_FIXTURE.js",
                   "raw": "'./empty_FIXTURE.js'"
                 },
-                "options": null
+                "options": null,
+                "phase": null
               }
             }
           }

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-async-function-script-code-valid.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-async-function-script-code-valid.json
@@ -78,7 +78,8 @@
                 "value": "./empty_FIXTURE.js",
                 "raw": "'./empty_FIXTURE.js'"
               },
-              "options": null
+              "options": null,
+              "phase": null
             }
           }
         ]

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-async-gen-await-empty-str-is-valid-assign-expr.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-async-gen-await-empty-str-is-valid-assign-expr.json
@@ -41,7 +41,8 @@
                   "value": "",
                   "raw": "''"
                 },
-                "options": null
+                "options": null,
+                "phase": null
               }
             }
           }

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-async-gen-await-import-attributes-trailing-comma-first.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-async-gen-await-import-attributes-trailing-comma-first.json
@@ -41,7 +41,8 @@
                   "value": "./empty_FIXTURE.js",
                   "raw": "'./empty_FIXTURE.js'"
                 },
-                "options": null
+                "options": null,
+                "phase": null
               }
             }
           }

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-async-gen-await-import-attributes-trailing-comma-second.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-async-gen-await-import-attributes-trailing-comma-second.json
@@ -46,7 +46,8 @@
                   "start": 1396,
                   "end": 1398,
                   "properties": []
-                }
+                },
+                "phase": null
               }
             }
           }

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-async-gen-await-nested-imports.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-async-gen-await-nested-imports.json
@@ -49,11 +49,14 @@
                       "value": "./empty_FIXTURE.js",
                       "raw": "'./empty_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   },
-                  "options": null
+                  "options": null,
+                  "phase": null
                 },
-                "options": null
+                "options": null,
+                "phase": null
               }
             }
           }

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-async-gen-await-script-code-valid.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-async-gen-await-script-code-valid.json
@@ -82,7 +82,8 @@
                   "value": "./empty_FIXTURE.js",
                   "raw": "'./empty_FIXTURE.js'"
                 },
-                "options": null
+                "options": null,
+                "phase": null
               }
             }
           }

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-block-empty-str-is-valid-assign-expr.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-block-empty-str-is-valid-assign-expr.json
@@ -23,7 +23,8 @@
               "value": "",
               "raw": "''"
             },
-            "options": null
+            "options": null,
+            "phase": null
           }
         }
       ]

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-block-import-attributes-trailing-comma-first.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-block-import-attributes-trailing-comma-first.json
@@ -23,7 +23,8 @@
               "value": "./empty_FIXTURE.js",
               "raw": "'./empty_FIXTURE.js'"
             },
-            "options": null
+            "options": null,
+            "phase": null
           }
         }
       ]

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-block-import-attributes-trailing-comma-second.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-block-import-attributes-trailing-comma-second.json
@@ -28,7 +28,8 @@
               "start": 1321,
               "end": 1323,
               "properties": []
-            }
+            },
+            "phase": null
           }
         }
       ]

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-block-labeled-empty-str-is-valid-assign-expr.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-block-labeled-empty-str-is-valid-assign-expr.json
@@ -27,7 +27,8 @@
                 "value": "",
                 "raw": "''"
               },
-              "options": null
+              "options": null,
+              "phase": null
             }
           }
         ]

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-block-labeled-import-attributes-trailing-comma-first.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-block-labeled-import-attributes-trailing-comma-first.json
@@ -27,7 +27,8 @@
                 "value": "./empty_FIXTURE.js",
                 "raw": "'./empty_FIXTURE.js'"
               },
-              "options": null
+              "options": null,
+              "phase": null
             }
           }
         ]

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-block-labeled-import-attributes-trailing-comma-second.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-block-labeled-import-attributes-trailing-comma-second.json
@@ -32,7 +32,8 @@
                 "start": 1336,
                 "end": 1338,
                 "properties": []
-              }
+              },
+              "phase": null
             }
           }
         ]

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-block-labeled-nested-imports.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-block-labeled-nested-imports.json
@@ -35,11 +35,14 @@
                     "value": "./empty_FIXTURE.js",
                     "raw": "'./empty_FIXTURE.js'"
                   },
-                  "options": null
+                  "options": null,
+                  "phase": null
                 },
-                "options": null
+                "options": null,
+                "phase": null
               },
-              "options": null
+              "options": null,
+              "phase": null
             }
           }
         ]

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-block-labeled-script-code-valid.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-block-labeled-script-code-valid.json
@@ -68,7 +68,8 @@
                 "value": "./empty_FIXTURE.js",
                 "raw": "'./empty_FIXTURE.js'"
               },
-              "options": null
+              "options": null,
+              "phase": null
             }
           }
         ]

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-block-nested-imports.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-block-nested-imports.json
@@ -31,11 +31,14 @@
                   "value": "./empty_FIXTURE.js",
                   "raw": "'./empty_FIXTURE.js'"
                 },
-                "options": null
+                "options": null,
+                "phase": null
               },
-              "options": null
+              "options": null,
+              "phase": null
             },
-            "options": null
+            "options": null,
+            "phase": null
           }
         }
       ]

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-block-script-code-valid.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-block-script-code-valid.json
@@ -64,7 +64,8 @@
               "value": "./empty_FIXTURE.js",
               "raw": "'./empty_FIXTURE.js'"
             },
-            "options": null
+            "options": null,
+            "phase": null
           }
         }
       ]

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-do-while-empty-str-is-valid-assign-expr.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-do-while-empty-str-is-valid-assign-expr.json
@@ -27,7 +27,8 @@
                 "value": "",
                 "raw": "''"
               },
-              "options": null
+              "options": null,
+              "phase": null
             }
           }
         ]

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-do-while-import-attributes-trailing-comma-first.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-do-while-import-attributes-trailing-comma-first.json
@@ -27,7 +27,8 @@
                 "value": "./empty_FIXTURE.js",
                 "raw": "'./empty_FIXTURE.js'"
               },
-              "options": null
+              "options": null,
+              "phase": null
             }
           }
         ]

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-do-while-import-attributes-trailing-comma-second.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-do-while-import-attributes-trailing-comma-second.json
@@ -32,7 +32,8 @@
                 "start": 1330,
                 "end": 1332,
                 "properties": []
-              }
+              },
+              "phase": null
             }
           }
         ]

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-do-while-nested-imports.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-do-while-nested-imports.json
@@ -35,11 +35,14 @@
                     "value": "./empty_FIXTURE.js",
                     "raw": "'./empty_FIXTURE.js'"
                   },
-                  "options": null
+                  "options": null,
+                  "phase": null
                 },
-                "options": null
+                "options": null,
+                "phase": null
               },
-              "options": null
+              "options": null,
+              "phase": null
             }
           }
         ]

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-do-while-script-code-valid.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-do-while-script-code-valid.json
@@ -68,7 +68,8 @@
                 "value": "./empty_FIXTURE.js",
                 "raw": "'./empty_FIXTURE.js'"
               },
-              "options": null
+              "options": null,
+              "phase": null
             }
           }
         ]

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-else-braceless-empty-str-is-valid-assign-expr.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-else-braceless-empty-str-is-valid-assign-expr.json
@@ -35,7 +35,8 @@
             "value": "",
             "raw": "''"
           },
-          "options": null
+          "options": null,
+          "phase": null
         }
       }
     }

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-else-braceless-import-attributes-trailing-comma-first.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-else-braceless-import-attributes-trailing-comma-first.json
@@ -35,7 +35,8 @@
             "value": "./empty_FIXTURE.js",
             "raw": "'./empty_FIXTURE.js'"
           },
-          "options": null
+          "options": null,
+          "phase": null
         }
       }
     }

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-else-braceless-import-attributes-trailing-comma-second.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-else-braceless-import-attributes-trailing-comma-second.json
@@ -40,7 +40,8 @@
             "start": 1346,
             "end": 1348,
             "properties": []
-          }
+          },
+          "phase": null
         }
       }
     }

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-else-braceless-nested-imports.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-else-braceless-nested-imports.json
@@ -43,11 +43,14 @@
                 "value": "./empty_FIXTURE.js",
                 "raw": "'./empty_FIXTURE.js'"
               },
-              "options": null
+              "options": null,
+              "phase": null
             },
-            "options": null
+            "options": null,
+            "phase": null
           },
-          "options": null
+          "options": null,
+          "phase": null
         }
       }
     }

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-else-braceless-script-code-valid.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-else-braceless-script-code-valid.json
@@ -76,7 +76,8 @@
             "value": "./empty_FIXTURE.js",
             "raw": "'./empty_FIXTURE.js'"
           },
-          "options": null
+          "options": null,
+          "phase": null
         }
       }
     }

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-else-empty-str-is-valid-assign-expr.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-else-empty-str-is-valid-assign-expr.json
@@ -40,7 +40,8 @@
                 "value": "",
                 "raw": "''"
               },
-              "options": null
+              "options": null,
+              "phase": null
             }
           }
         ]

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-else-import-attributes-trailing-comma-first.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-else-import-attributes-trailing-comma-first.json
@@ -40,7 +40,8 @@
                 "value": "./empty_FIXTURE.js",
                 "raw": "'./empty_FIXTURE.js'"
               },
-              "options": null
+              "options": null,
+              "phase": null
             }
           }
         ]

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-else-import-attributes-trailing-comma-second.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-else-import-attributes-trailing-comma-second.json
@@ -45,7 +45,8 @@
                 "start": 1340,
                 "end": 1342,
                 "properties": []
-              }
+              },
+              "phase": null
             }
           }
         ]

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-else-nested-imports.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-else-nested-imports.json
@@ -48,11 +48,14 @@
                     "value": "./empty_FIXTURE.js",
                     "raw": "'./empty_FIXTURE.js'"
                   },
-                  "options": null
+                  "options": null,
+                  "phase": null
                 },
-                "options": null
+                "options": null,
+                "phase": null
               },
-              "options": null
+              "options": null,
+              "phase": null
             }
           }
         ]

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-else-script-code-valid.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-else-script-code-valid.json
@@ -81,7 +81,8 @@
                 "value": "./empty_FIXTURE.js",
                 "raw": "'./empty_FIXTURE.js'"
               },
-              "options": null
+              "options": null,
+              "phase": null
             }
           }
         ]

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-function-empty-str-is-valid-assign-expr.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-function-empty-str-is-valid-assign-expr.json
@@ -37,7 +37,8 @@
                 "value": "",
                 "raw": "''"
               },
-              "options": null
+              "options": null,
+              "phase": null
             }
           }
         ]

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-function-import-attributes-trailing-comma-first.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-function-import-attributes-trailing-comma-first.json
@@ -37,7 +37,8 @@
                 "value": "./empty_FIXTURE.js",
                 "raw": "'./empty_FIXTURE.js'"
               },
-              "options": null
+              "options": null,
+              "phase": null
             }
           }
         ]

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-function-import-attributes-trailing-comma-second.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-function-import-attributes-trailing-comma-second.json
@@ -42,7 +42,8 @@
                 "start": 1341,
                 "end": 1343,
                 "properties": []
-              }
+              },
+              "phase": null
             }
           }
         ]

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-function-nested-imports.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-function-nested-imports.json
@@ -45,11 +45,14 @@
                     "value": "./empty_FIXTURE.js",
                     "raw": "'./empty_FIXTURE.js'"
                   },
-                  "options": null
+                  "options": null,
+                  "phase": null
                 },
-                "options": null
+                "options": null,
+                "phase": null
               },
-              "options": null
+              "options": null,
+              "phase": null
             }
           }
         ]

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-function-return-empty-str-is-valid-assign-expr.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-function-return-empty-str-is-valid-assign-expr.json
@@ -37,7 +37,8 @@
                 "value": "",
                 "raw": "''"
               },
-              "options": null
+              "options": null,
+              "phase": null
             }
           }
         ]

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-function-return-import-attributes-trailing-comma-first.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-function-return-import-attributes-trailing-comma-first.json
@@ -37,7 +37,8 @@
                 "value": "./empty_FIXTURE.js",
                 "raw": "'./empty_FIXTURE.js'"
               },
-              "options": null
+              "options": null,
+              "phase": null
             }
           }
         ]

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-function-return-import-attributes-trailing-comma-second.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-function-return-import-attributes-trailing-comma-second.json
@@ -42,7 +42,8 @@
                 "start": 1355,
                 "end": 1357,
                 "properties": []
-              }
+              },
+              "phase": null
             }
           }
         ]

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-function-return-nested-imports.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-function-return-nested-imports.json
@@ -45,11 +45,14 @@
                     "value": "./empty_FIXTURE.js",
                     "raw": "'./empty_FIXTURE.js'"
                   },
-                  "options": null
+                  "options": null,
+                  "phase": null
                 },
-                "options": null
+                "options": null,
+                "phase": null
               },
-              "options": null
+              "options": null,
+              "phase": null
             }
           }
         ]

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-function-return-script-code-valid.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-function-return-script-code-valid.json
@@ -78,7 +78,8 @@
                 "value": "./empty_FIXTURE.js",
                 "raw": "'./empty_FIXTURE.js'"
               },
-              "options": null
+              "options": null,
+              "phase": null
             }
           }
         ]

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-function-script-code-valid.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-function-script-code-valid.json
@@ -78,7 +78,8 @@
                 "value": "./empty_FIXTURE.js",
                 "raw": "'./empty_FIXTURE.js'"
               },
-              "options": null
+              "options": null,
+              "phase": null
             }
           }
         ]

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-if-braceless-empty-str-is-valid-assign-expr.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-if-braceless-empty-str-is-valid-assign-expr.json
@@ -29,7 +29,8 @@
             "value": "",
             "raw": "''"
           },
-          "options": null
+          "options": null,
+          "phase": null
         }
       },
       "alternate": null

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-if-braceless-import-attributes-trailing-comma-first.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-if-braceless-import-attributes-trailing-comma-first.json
@@ -29,7 +29,8 @@
             "value": "./empty_FIXTURE.js",
             "raw": "'./empty_FIXTURE.js'"
           },
-          "options": null
+          "options": null,
+          "phase": null
         }
       },
       "alternate": null

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-if-braceless-import-attributes-trailing-comma-second.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-if-braceless-import-attributes-trailing-comma-second.json
@@ -34,7 +34,8 @@
             "start": 1331,
             "end": 1333,
             "properties": []
-          }
+          },
+          "phase": null
         }
       },
       "alternate": null

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-if-braceless-nested-imports.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-if-braceless-nested-imports.json
@@ -37,11 +37,14 @@
                 "value": "./empty_FIXTURE.js",
                 "raw": "'./empty_FIXTURE.js'"
               },
-              "options": null
+              "options": null,
+              "phase": null
             },
-            "options": null
+            "options": null,
+            "phase": null
           },
-          "options": null
+          "options": null,
+          "phase": null
         }
       },
       "alternate": null

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-if-braceless-script-code-valid.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-if-braceless-script-code-valid.json
@@ -70,7 +70,8 @@
             "value": "./empty_FIXTURE.js",
             "raw": "'./empty_FIXTURE.js'"
           },
-          "options": null
+          "options": null,
+          "phase": null
         }
       },
       "alternate": null

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-if-empty-str-is-valid-assign-expr.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-if-empty-str-is-valid-assign-expr.json
@@ -34,7 +34,8 @@
                 "value": "",
                 "raw": "''"
               },
-              "options": null
+              "options": null,
+              "phase": null
             }
           }
         ]

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-if-import-attributes-trailing-comma-first.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-if-import-attributes-trailing-comma-first.json
@@ -34,7 +34,8 @@
                 "value": "./empty_FIXTURE.js",
                 "raw": "'./empty_FIXTURE.js'"
               },
-              "options": null
+              "options": null,
+              "phase": null
             }
           }
         ]

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-if-import-attributes-trailing-comma-second.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-if-import-attributes-trailing-comma-second.json
@@ -39,7 +39,8 @@
                 "start": 1325,
                 "end": 1327,
                 "properties": []
-              }
+              },
+              "phase": null
             }
           }
         ]

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-if-nested-imports.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-if-nested-imports.json
@@ -42,11 +42,14 @@
                     "value": "./empty_FIXTURE.js",
                     "raw": "'./empty_FIXTURE.js'"
                   },
-                  "options": null
+                  "options": null,
+                  "phase": null
                 },
-                "options": null
+                "options": null,
+                "phase": null
               },
-              "options": null
+              "options": null,
+              "phase": null
             }
           }
         ]

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-if-script-code-valid.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-if-script-code-valid.json
@@ -75,7 +75,8 @@
                 "value": "./empty_FIXTURE.js",
                 "raw": "'./empty_FIXTURE.js'"
               },
-              "options": null
+              "options": null,
+              "phase": null
             }
           }
         ]

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-while-empty-str-is-valid-assign-expr.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-while-empty-str-is-valid-assign-expr.json
@@ -84,7 +84,8 @@
                 "value": "",
                 "raw": "''"
               },
-              "options": null
+              "options": null,
+              "phase": null
             }
           }
         ]

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-while-import-attributes-trailing-comma-first.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-while-import-attributes-trailing-comma-first.json
@@ -84,7 +84,8 @@
                 "value": "./empty_FIXTURE.js",
                 "raw": "'./empty_FIXTURE.js'"
               },
-              "options": null
+              "options": null,
+              "phase": null
             }
           }
         ]

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-while-import-attributes-trailing-comma-second.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-while-import-attributes-trailing-comma-second.json
@@ -89,7 +89,8 @@
                 "start": 1350,
                 "end": 1352,
                 "properties": []
-              }
+              },
+              "phase": null
             }
           }
         ]

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-while-nested-imports.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-while-nested-imports.json
@@ -92,11 +92,14 @@
                     "value": "./empty_FIXTURE.js",
                     "raw": "'./empty_FIXTURE.js'"
                   },
-                  "options": null
+                  "options": null,
+                  "phase": null
                 },
-                "options": null
+                "options": null,
+                "phase": null
               },
-              "options": null
+              "options": null,
+              "phase": null
             }
           }
         ]

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-while-script-code-valid.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-while-script-code-valid.json
@@ -125,7 +125,8 @@
                 "value": "./empty_FIXTURE.js",
                 "raw": "'./empty_FIXTURE.js'"
               },
-              "options": null
+              "options": null,
+              "phase": null
             }
           }
         ]

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-with-empty-str-is-valid-assign-expr.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-with-empty-str-is-valid-assign-expr.json
@@ -33,7 +33,8 @@
                 "value": "",
                 "raw": "''"
               },
-              "options": null
+              "options": null,
+              "phase": null
             }
           }
         ]

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-with-expression-empty-str-is-valid-assign-expr.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-with-expression-empty-str-is-valid-assign-expr.json
@@ -18,7 +18,8 @@
           "value": "",
           "raw": "''"
         },
-        "options": null
+        "options": null,
+        "phase": null
       },
       "body": {
         "type": "BlockStatement",

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-with-expression-import-attributes-trailing-comma-first.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-with-expression-import-attributes-trailing-comma-first.json
@@ -18,7 +18,8 @@
           "value": "./empty_FIXTURE.js",
           "raw": "'./empty_FIXTURE.js'"
         },
-        "options": null
+        "options": null,
+        "phase": null
       },
       "body": {
         "type": "BlockStatement",

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-with-expression-import-attributes-trailing-comma-second.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-with-expression-import-attributes-trailing-comma-second.json
@@ -23,7 +23,8 @@
           "start": 1369,
           "end": 1371,
           "properties": []
-        }
+        },
+        "phase": null
       },
       "body": {
         "type": "BlockStatement",

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-with-expression-nested-imports.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-with-expression-nested-imports.json
@@ -26,11 +26,14 @@
               "value": "./empty_FIXTURE.js",
               "raw": "'./empty_FIXTURE.js'"
             },
-            "options": null
+            "options": null,
+            "phase": null
           },
-          "options": null
+          "options": null,
+          "phase": null
         },
-        "options": null
+        "options": null,
+        "phase": null
       },
       "body": {
         "type": "BlockStatement",

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-with-expression-script-code-valid.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-with-expression-script-code-valid.json
@@ -59,7 +59,8 @@
           "value": "./empty_FIXTURE.js",
           "raw": "'./empty_FIXTURE.js'"
         },
-        "options": null
+        "options": null,
+        "phase": null
       },
       "body": {
         "type": "BlockStatement",

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-with-import-attributes-trailing-comma-first.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-with-import-attributes-trailing-comma-first.json
@@ -33,7 +33,8 @@
                 "value": "./empty_FIXTURE.js",
                 "raw": "'./empty_FIXTURE.js'"
               },
-              "options": null
+              "options": null,
+              "phase": null
             }
           }
         ]

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-with-import-attributes-trailing-comma-second.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-with-import-attributes-trailing-comma-second.json
@@ -38,7 +38,8 @@
                 "start": 1339,
                 "end": 1341,
                 "properties": []
-              }
+              },
+              "phase": null
             }
           }
         ]

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-with-nested-imports.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-with-nested-imports.json
@@ -41,11 +41,14 @@
                     "value": "./empty_FIXTURE.js",
                     "raw": "'./empty_FIXTURE.js'"
                   },
-                  "options": null
+                  "options": null,
+                  "phase": null
                 },
-                "options": null
+                "options": null,
+                "phase": null
               },
-              "options": null
+              "options": null,
+              "phase": null
             }
           }
         ]

--- a/test/language/expressions/dynamic-import/syntax/valid/nested-with-script-code-valid.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/nested-with-script-code-valid.json
@@ -74,7 +74,8 @@
                 "value": "./empty_FIXTURE.js",
                 "raw": "'./empty_FIXTURE.js'"
               },
-              "options": null
+              "options": null,
+              "phase": null
             }
           }
         ]

--- a/test/language/expressions/dynamic-import/syntax/valid/new-covered-expression-is-valid.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/new-covered-expression-is-valid.json
@@ -74,7 +74,8 @@
                           "value": "",
                           "raw": "''"
                         },
-                        "options": null
+                        "options": null,
+                        "phase": null
                       }
                     },
                     "arguments": []
@@ -179,7 +180,8 @@
                               "value": "",
                               "raw": "''"
                             },
-                            "options": null
+                            "options": null,
+                            "phase": null
                           }
                         ]
                       }
@@ -252,7 +254,8 @@
                         "value": "",
                         "raw": "''"
                       },
-                      "options": null
+                      "options": null,
+                      "phase": null
                     },
                     {
                       "type": "FunctionExpression",

--- a/test/language/expressions/dynamic-import/syntax/valid/top-level-empty-str-is-valid-assign-expr.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/top-level-empty-str-is-valid-assign-expr.json
@@ -18,7 +18,8 @@
           "value": "",
           "raw": "''"
         },
-        "options": null
+        "options": null,
+        "phase": null
       }
     }
   ],

--- a/test/language/expressions/dynamic-import/syntax/valid/top-level-import-attributes-trailing-comma-first.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/top-level-import-attributes-trailing-comma-first.json
@@ -18,7 +18,8 @@
           "value": "./empty_FIXTURE.js",
           "raw": "'./empty_FIXTURE.js'"
         },
-        "options": null
+        "options": null,
+        "phase": null
       }
     }
   ],

--- a/test/language/expressions/dynamic-import/syntax/valid/top-level-import-attributes-trailing-comma-second.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/top-level-import-attributes-trailing-comma-second.json
@@ -23,7 +23,8 @@
           "start": 694,
           "end": 696,
           "properties": []
-        }
+        },
+        "phase": null
       }
     }
   ],

--- a/test/language/expressions/dynamic-import/syntax/valid/top-level-nested-imports.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/top-level-nested-imports.json
@@ -26,11 +26,14 @@
               "value": "./empty_FIXTURE.js",
               "raw": "'./empty_FIXTURE.js'"
             },
-            "options": null
+            "options": null,
+            "phase": null
           },
-          "options": null
+          "options": null,
+          "phase": null
         },
-        "options": null
+        "options": null,
+        "phase": null
       }
     }
   ],

--- a/test/language/expressions/dynamic-import/syntax/valid/top-level-script-code-valid.json
+++ b/test/language/expressions/dynamic-import/syntax/valid/top-level-script-code-valid.json
@@ -59,7 +59,8 @@
           "value": "./empty_FIXTURE.js",
           "raw": "'./empty_FIXTURE.js'"
         },
-        "options": null
+        "options": null,
+        "phase": null
       }
     }
   ],

--- a/test/language/expressions/dynamic-import/update-to-dynamic-import.json
+++ b/test/language/expressions/dynamic-import/update-to-dynamic-import.json
@@ -52,7 +52,8 @@
                       "value": "./update-to-dynamic-import_FIXTURE.js",
                       "raw": "'./update-to-dynamic-import_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   }
                 }
               }

--- a/test/language/expressions/dynamic-import/usage/nested-arrow-assignment-expression-eval-gtbndng-indirect-update-dflt.json
+++ b/test/language/expressions/dynamic-import/usage/nested-arrow-assignment-expression-eval-gtbndng-indirect-update-dflt.json
@@ -46,7 +46,8 @@
                     "value": "./eval-gtbndng-indirect-update-dflt_FIXTURE.js",
                     "raw": "'./eval-gtbndng-indirect-update-dflt_FIXTURE.js'"
                   },
-                  "options": null
+                  "options": null,
+                  "phase": null
                 },
                 "property": {
                   "type": "Identifier",

--- a/test/language/expressions/dynamic-import/usage/nested-arrow-assignment-expression-eval-gtbndng-indirect-update.json
+++ b/test/language/expressions/dynamic-import/usage/nested-arrow-assignment-expression-eval-gtbndng-indirect-update.json
@@ -46,7 +46,8 @@
                     "value": "./eval-gtbndng-indirect-update_FIXTURE.js",
                     "raw": "'./eval-gtbndng-indirect-update_FIXTURE.js'"
                   },
-                  "options": null
+                  "options": null,
+                  "phase": null
                 },
                 "property": {
                   "type": "Identifier",

--- a/test/language/expressions/dynamic-import/usage/nested-arrow-assignment-expression-eval-script-code-host-resolves-module-code.json
+++ b/test/language/expressions/dynamic-import/usage/nested-arrow-assignment-expression-eval-script-code-host-resolves-module-code.json
@@ -87,7 +87,8 @@
                     "value": "./module-code_FIXTURE.js",
                     "raw": "'./module-code_FIXTURE.js'"
                   },
-                  "options": null
+                  "options": null,
+                  "phase": null
                 },
                 "property": {
                   "type": "Identifier",

--- a/test/language/expressions/dynamic-import/usage/nested-arrow-assignment-expression-is-call-expression-square-brackets.json
+++ b/test/language/expressions/dynamic-import/usage/nested-arrow-assignment-expression-is-call-expression-square-brackets.json
@@ -54,7 +54,8 @@
                         "value": "./dynamic-import-module_FIXTURE.js",
                         "raw": "'./dynamic-import-module_FIXTURE.js'"
                       },
-                      "options": null
+                      "options": null,
+                      "phase": null
                     },
                     "property": {
                       "type": "Literal",

--- a/test/language/expressions/dynamic-import/usage/nested-arrow-assignment-expression-returns-thenable.json
+++ b/test/language/expressions/dynamic-import/usage/nested-arrow-assignment-expression-returns-thenable.json
@@ -46,7 +46,8 @@
                     "value": "./dynamic-import-module_FIXTURE.js",
                     "raw": "'./dynamic-import-module_FIXTURE.js'"
                   },
-                  "options": null
+                  "options": null,
+                  "phase": null
                 },
                 "property": {
                   "type": "Identifier",

--- a/test/language/expressions/dynamic-import/usage/nested-arrow-assignment-expression-specifier-tostring.json
+++ b/test/language/expressions/dynamic-import/usage/nested-arrow-assignment-expression-specifier-tostring.json
@@ -115,7 +115,8 @@
                     "end": 1805,
                     "name": "obj"
                   },
-                  "options": null
+                  "options": null,
+                  "phase": null
                 },
                 "property": {
                   "type": "Identifier",

--- a/test/language/expressions/dynamic-import/usage/nested-arrow-import-then-eval-gtbndng-indirect-update-dflt.json
+++ b/test/language/expressions/dynamic-import/usage/nested-arrow-import-then-eval-gtbndng-indirect-update-dflt.json
@@ -71,7 +71,8 @@
                                   "value": "./eval-gtbndng-indirect-update-dflt_FIXTURE.js",
                                   "raw": "'./eval-gtbndng-indirect-update-dflt_FIXTURE.js'"
                                 },
-                                "options": null
+                                "options": null,
+                                "phase": null
                               },
                               "property": {
                                 "type": "Identifier",

--- a/test/language/expressions/dynamic-import/usage/nested-arrow-import-then-eval-gtbndng-indirect-update.json
+++ b/test/language/expressions/dynamic-import/usage/nested-arrow-import-then-eval-gtbndng-indirect-update.json
@@ -71,7 +71,8 @@
                                   "value": "./eval-gtbndng-indirect-update_FIXTURE.js",
                                   "raw": "'./eval-gtbndng-indirect-update_FIXTURE.js'"
                                 },
-                                "options": null
+                                "options": null,
+                                "phase": null
                               },
                               "property": {
                                 "type": "Identifier",

--- a/test/language/expressions/dynamic-import/usage/nested-arrow-import-then-eval-script-code-host-resolves-module-code.json
+++ b/test/language/expressions/dynamic-import/usage/nested-arrow-import-then-eval-script-code-host-resolves-module-code.json
@@ -112,7 +112,8 @@
                                   "value": "./module-code_FIXTURE.js",
                                   "raw": "'./module-code_FIXTURE.js'"
                                 },
-                                "options": null
+                                "options": null,
+                                "phase": null
                               },
                               "property": {
                                 "type": "Identifier",

--- a/test/language/expressions/dynamic-import/usage/nested-arrow-import-then-is-call-expression-square-brackets.json
+++ b/test/language/expressions/dynamic-import/usage/nested-arrow-import-then-is-call-expression-square-brackets.json
@@ -79,7 +79,8 @@
                                       "value": "./dynamic-import-module_FIXTURE.js",
                                       "raw": "'./dynamic-import-module_FIXTURE.js'"
                                     },
-                                    "options": null
+                                    "options": null,
+                                    "phase": null
                                   },
                                   "property": {
                                     "type": "Literal",

--- a/test/language/expressions/dynamic-import/usage/nested-arrow-import-then-returns-thenable.json
+++ b/test/language/expressions/dynamic-import/usage/nested-arrow-import-then-returns-thenable.json
@@ -71,7 +71,8 @@
                                   "value": "./dynamic-import-module_FIXTURE.js",
                                   "raw": "'./dynamic-import-module_FIXTURE.js'"
                                 },
-                                "options": null
+                                "options": null,
+                                "phase": null
                               },
                               "property": {
                                 "type": "Identifier",

--- a/test/language/expressions/dynamic-import/usage/nested-arrow-import-then-specifier-tostring.json
+++ b/test/language/expressions/dynamic-import/usage/nested-arrow-import-then-specifier-tostring.json
@@ -140,7 +140,8 @@
                                   "end": 1804,
                                   "name": "obj"
                                 },
-                                "options": null
+                                "options": null,
+                                "phase": null
                               },
                               "property": {
                                 "type": "Identifier",

--- a/test/language/expressions/dynamic-import/usage/nested-async-arrow-function-await-eval-gtbndng-indirect-update-dflt.json
+++ b/test/language/expressions/dynamic-import/usage/nested-async-arrow-function-await-eval-gtbndng-indirect-update-dflt.json
@@ -59,7 +59,8 @@
                             "value": "./eval-gtbndng-indirect-update-dflt_FIXTURE.js",
                             "raw": "'./eval-gtbndng-indirect-update-dflt_FIXTURE.js'"
                           },
-                          "options": null
+                          "options": null,
+                          "phase": null
                         },
                         "property": {
                           "type": "Identifier",

--- a/test/language/expressions/dynamic-import/usage/nested-async-arrow-function-await-eval-gtbndng-indirect-update.json
+++ b/test/language/expressions/dynamic-import/usage/nested-async-arrow-function-await-eval-gtbndng-indirect-update.json
@@ -59,7 +59,8 @@
                             "value": "./eval-gtbndng-indirect-update_FIXTURE.js",
                             "raw": "'./eval-gtbndng-indirect-update_FIXTURE.js'"
                           },
-                          "options": null
+                          "options": null,
+                          "phase": null
                         },
                         "property": {
                           "type": "Identifier",

--- a/test/language/expressions/dynamic-import/usage/nested-async-arrow-function-await-eval-script-code-host-resolves-module-code.json
+++ b/test/language/expressions/dynamic-import/usage/nested-async-arrow-function-await-eval-script-code-host-resolves-module-code.json
@@ -100,7 +100,8 @@
                             "value": "./module-code_FIXTURE.js",
                             "raw": "'./module-code_FIXTURE.js'"
                           },
-                          "options": null
+                          "options": null,
+                          "phase": null
                         },
                         "property": {
                           "type": "Identifier",

--- a/test/language/expressions/dynamic-import/usage/nested-async-arrow-function-await-is-call-expression-square-brackets.json
+++ b/test/language/expressions/dynamic-import/usage/nested-async-arrow-function-await-is-call-expression-square-brackets.json
@@ -67,7 +67,8 @@
                                 "value": "./dynamic-import-module_FIXTURE.js",
                                 "raw": "'./dynamic-import-module_FIXTURE.js'"
                               },
-                              "options": null
+                              "options": null,
+                              "phase": null
                             },
                             "property": {
                               "type": "Literal",

--- a/test/language/expressions/dynamic-import/usage/nested-async-arrow-function-await-returns-thenable.json
+++ b/test/language/expressions/dynamic-import/usage/nested-async-arrow-function-await-returns-thenable.json
@@ -59,7 +59,8 @@
                             "value": "./dynamic-import-module_FIXTURE.js",
                             "raw": "'./dynamic-import-module_FIXTURE.js'"
                           },
-                          "options": null
+                          "options": null,
+                          "phase": null
                         },
                         "property": {
                           "type": "Identifier",

--- a/test/language/expressions/dynamic-import/usage/nested-async-arrow-function-await-specifier-tostring.json
+++ b/test/language/expressions/dynamic-import/usage/nested-async-arrow-function-await-specifier-tostring.json
@@ -128,7 +128,8 @@
                             "end": 1853,
                             "name": "obj"
                           },
-                          "options": null
+                          "options": null,
+                          "phase": null
                         },
                         "property": {
                           "type": "Identifier",

--- a/test/language/expressions/dynamic-import/usage/nested-async-arrow-function-return-await-eval-gtbndng-indirect-update-dflt.json
+++ b/test/language/expressions/dynamic-import/usage/nested-async-arrow-function-return-await-eval-gtbndng-indirect-update-dflt.json
@@ -42,7 +42,8 @@
                   "value": "./eval-gtbndng-indirect-update-dflt_FIXTURE.js",
                   "raw": "'./eval-gtbndng-indirect-update-dflt_FIXTURE.js'"
                 },
-                "options": null
+                "options": null,
+                "phase": null
               }
             }
           }

--- a/test/language/expressions/dynamic-import/usage/nested-async-arrow-function-return-await-eval-gtbndng-indirect-update.json
+++ b/test/language/expressions/dynamic-import/usage/nested-async-arrow-function-return-await-eval-gtbndng-indirect-update.json
@@ -42,7 +42,8 @@
                   "value": "./eval-gtbndng-indirect-update_FIXTURE.js",
                   "raw": "'./eval-gtbndng-indirect-update_FIXTURE.js'"
                 },
-                "options": null
+                "options": null,
+                "phase": null
               }
             }
           }

--- a/test/language/expressions/dynamic-import/usage/nested-async-arrow-function-return-await-eval-script-code-host-resolves-module-code.json
+++ b/test/language/expressions/dynamic-import/usage/nested-async-arrow-function-return-await-eval-script-code-host-resolves-module-code.json
@@ -83,7 +83,8 @@
                   "value": "./module-code_FIXTURE.js",
                   "raw": "'./module-code_FIXTURE.js'"
                 },
-                "options": null
+                "options": null,
+                "phase": null
               }
             }
           }

--- a/test/language/expressions/dynamic-import/usage/nested-async-arrow-function-return-await-is-call-expression-square-brackets.json
+++ b/test/language/expressions/dynamic-import/usage/nested-async-arrow-function-return-await-is-call-expression-square-brackets.json
@@ -50,7 +50,8 @@
                       "value": "./dynamic-import-module_FIXTURE.js",
                       "raw": "'./dynamic-import-module_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   },
                   "property": {
                     "type": "Literal",

--- a/test/language/expressions/dynamic-import/usage/nested-async-arrow-function-return-await-returns-thenable.json
+++ b/test/language/expressions/dynamic-import/usage/nested-async-arrow-function-return-await-returns-thenable.json
@@ -42,7 +42,8 @@
                   "value": "./dynamic-import-module_FIXTURE.js",
                   "raw": "'./dynamic-import-module_FIXTURE.js'"
                 },
-                "options": null
+                "options": null,
+                "phase": null
               }
             }
           }

--- a/test/language/expressions/dynamic-import/usage/nested-async-arrow-function-return-await-specifier-tostring.json
+++ b/test/language/expressions/dynamic-import/usage/nested-async-arrow-function-return-await-specifier-tostring.json
@@ -111,7 +111,8 @@
                   "end": 1857,
                   "name": "obj"
                 },
-                "options": null
+                "options": null,
+                "phase": null
               }
             }
           }

--- a/test/language/expressions/dynamic-import/usage/nested-async-function-await-eval-gtbndng-indirect-update-dflt.json
+++ b/test/language/expressions/dynamic-import/usage/nested-async-function-await-eval-gtbndng-indirect-update-dflt.json
@@ -49,7 +49,8 @@
                       "value": "./eval-gtbndng-indirect-update-dflt_FIXTURE.js",
                       "raw": "'./eval-gtbndng-indirect-update-dflt_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   },
                   "property": {
                     "type": "Identifier",

--- a/test/language/expressions/dynamic-import/usage/nested-async-function-await-eval-gtbndng-indirect-update.json
+++ b/test/language/expressions/dynamic-import/usage/nested-async-function-await-eval-gtbndng-indirect-update.json
@@ -49,7 +49,8 @@
                       "value": "./eval-gtbndng-indirect-update_FIXTURE.js",
                       "raw": "'./eval-gtbndng-indirect-update_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   },
                   "property": {
                     "type": "Identifier",

--- a/test/language/expressions/dynamic-import/usage/nested-async-function-await-eval-script-code-host-resolves-module-code.json
+++ b/test/language/expressions/dynamic-import/usage/nested-async-function-await-eval-script-code-host-resolves-module-code.json
@@ -90,7 +90,8 @@
                       "value": "./module-code_FIXTURE.js",
                       "raw": "'./module-code_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   },
                   "property": {
                     "type": "Identifier",

--- a/test/language/expressions/dynamic-import/usage/nested-async-function-await-is-call-expression-square-brackets.json
+++ b/test/language/expressions/dynamic-import/usage/nested-async-function-await-is-call-expression-square-brackets.json
@@ -57,7 +57,8 @@
                           "value": "./dynamic-import-module_FIXTURE.js",
                           "raw": "'./dynamic-import-module_FIXTURE.js'"
                         },
-                        "options": null
+                        "options": null,
+                        "phase": null
                       },
                       "property": {
                         "type": "Literal",

--- a/test/language/expressions/dynamic-import/usage/nested-async-function-await-returns-thenable.json
+++ b/test/language/expressions/dynamic-import/usage/nested-async-function-await-returns-thenable.json
@@ -49,7 +49,8 @@
                       "value": "./dynamic-import-module_FIXTURE.js",
                       "raw": "'./dynamic-import-module_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   },
                   "property": {
                     "type": "Identifier",

--- a/test/language/expressions/dynamic-import/usage/nested-async-function-await-specifier-tostring.json
+++ b/test/language/expressions/dynamic-import/usage/nested-async-function-await-specifier-tostring.json
@@ -118,7 +118,8 @@
                       "end": 1844,
                       "name": "obj"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   },
                   "property": {
                     "type": "Identifier",

--- a/test/language/expressions/dynamic-import/usage/nested-async-function-eval-gtbndng-indirect-update-dflt.json
+++ b/test/language/expressions/dynamic-import/usage/nested-async-function-eval-gtbndng-indirect-update-dflt.json
@@ -61,7 +61,8 @@
                             "value": "./eval-gtbndng-indirect-update-dflt_FIXTURE.js",
                             "raw": "'./eval-gtbndng-indirect-update-dflt_FIXTURE.js'"
                           },
-                          "options": null
+                          "options": null,
+                          "phase": null
                         },
                         "property": {
                           "type": "Identifier",

--- a/test/language/expressions/dynamic-import/usage/nested-async-function-eval-gtbndng-indirect-update.json
+++ b/test/language/expressions/dynamic-import/usage/nested-async-function-eval-gtbndng-indirect-update.json
@@ -61,7 +61,8 @@
                             "value": "./eval-gtbndng-indirect-update_FIXTURE.js",
                             "raw": "'./eval-gtbndng-indirect-update_FIXTURE.js'"
                           },
-                          "options": null
+                          "options": null,
+                          "phase": null
                         },
                         "property": {
                           "type": "Identifier",

--- a/test/language/expressions/dynamic-import/usage/nested-async-function-eval-script-code-host-resolves-module-code.json
+++ b/test/language/expressions/dynamic-import/usage/nested-async-function-eval-script-code-host-resolves-module-code.json
@@ -102,7 +102,8 @@
                             "value": "./module-code_FIXTURE.js",
                             "raw": "'./module-code_FIXTURE.js'"
                           },
-                          "options": null
+                          "options": null,
+                          "phase": null
                         },
                         "property": {
                           "type": "Identifier",

--- a/test/language/expressions/dynamic-import/usage/nested-async-function-is-call-expression-square-brackets.json
+++ b/test/language/expressions/dynamic-import/usage/nested-async-function-is-call-expression-square-brackets.json
@@ -69,7 +69,8 @@
                                 "value": "./dynamic-import-module_FIXTURE.js",
                                 "raw": "'./dynamic-import-module_FIXTURE.js'"
                               },
-                              "options": null
+                              "options": null,
+                              "phase": null
                             },
                             "property": {
                               "type": "Literal",

--- a/test/language/expressions/dynamic-import/usage/nested-async-function-return-await-eval-gtbndng-indirect-update-dflt.json
+++ b/test/language/expressions/dynamic-import/usage/nested-async-function-return-await-eval-gtbndng-indirect-update-dflt.json
@@ -41,7 +41,8 @@
                   "value": "./eval-gtbndng-indirect-update-dflt_FIXTURE.js",
                   "raw": "'./eval-gtbndng-indirect-update-dflt_FIXTURE.js'"
                 },
-                "options": null
+                "options": null,
+                "phase": null
               }
             }
           }

--- a/test/language/expressions/dynamic-import/usage/nested-async-function-return-await-eval-gtbndng-indirect-update.json
+++ b/test/language/expressions/dynamic-import/usage/nested-async-function-return-await-eval-gtbndng-indirect-update.json
@@ -41,7 +41,8 @@
                   "value": "./eval-gtbndng-indirect-update_FIXTURE.js",
                   "raw": "'./eval-gtbndng-indirect-update_FIXTURE.js'"
                 },
-                "options": null
+                "options": null,
+                "phase": null
               }
             }
           }

--- a/test/language/expressions/dynamic-import/usage/nested-async-function-return-await-eval-script-code-host-resolves-module-code.json
+++ b/test/language/expressions/dynamic-import/usage/nested-async-function-return-await-eval-script-code-host-resolves-module-code.json
@@ -82,7 +82,8 @@
                   "value": "./module-code_FIXTURE.js",
                   "raw": "'./module-code_FIXTURE.js'"
                 },
-                "options": null
+                "options": null,
+                "phase": null
               }
             }
           }

--- a/test/language/expressions/dynamic-import/usage/nested-async-function-return-await-is-call-expression-square-brackets.json
+++ b/test/language/expressions/dynamic-import/usage/nested-async-function-return-await-is-call-expression-square-brackets.json
@@ -49,7 +49,8 @@
                       "value": "./dynamic-import-module_FIXTURE.js",
                       "raw": "'./dynamic-import-module_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   },
                   "property": {
                     "type": "Literal",

--- a/test/language/expressions/dynamic-import/usage/nested-async-function-return-await-returns-thenable.json
+++ b/test/language/expressions/dynamic-import/usage/nested-async-function-return-await-returns-thenable.json
@@ -41,7 +41,8 @@
                   "value": "./dynamic-import-module_FIXTURE.js",
                   "raw": "'./dynamic-import-module_FIXTURE.js'"
                 },
-                "options": null
+                "options": null,
+                "phase": null
               }
             }
           }

--- a/test/language/expressions/dynamic-import/usage/nested-async-function-return-await-specifier-tostring.json
+++ b/test/language/expressions/dynamic-import/usage/nested-async-function-return-await-specifier-tostring.json
@@ -110,7 +110,8 @@
                   "end": 1866,
                   "name": "obj"
                 },
-                "options": null
+                "options": null,
+                "phase": null
               }
             }
           }

--- a/test/language/expressions/dynamic-import/usage/nested-async-function-returns-thenable.json
+++ b/test/language/expressions/dynamic-import/usage/nested-async-function-returns-thenable.json
@@ -61,7 +61,8 @@
                             "value": "./dynamic-import-module_FIXTURE.js",
                             "raw": "'./dynamic-import-module_FIXTURE.js'"
                           },
-                          "options": null
+                          "options": null,
+                          "phase": null
                         },
                         "property": {
                           "type": "Identifier",

--- a/test/language/expressions/dynamic-import/usage/nested-async-function-specifier-tostring.json
+++ b/test/language/expressions/dynamic-import/usage/nested-async-function-specifier-tostring.json
@@ -130,7 +130,8 @@
                             "end": 1823,
                             "name": "obj"
                           },
-                          "options": null
+                          "options": null,
+                          "phase": null
                         },
                         "property": {
                           "type": "Identifier",

--- a/test/language/expressions/dynamic-import/usage/nested-async-gen-await-eval-gtbndng-indirect-update-dflt.json
+++ b/test/language/expressions/dynamic-import/usage/nested-async-gen-await-eval-gtbndng-indirect-update-dflt.json
@@ -75,7 +75,8 @@
                       "value": "./eval-gtbndng-indirect-update-dflt_FIXTURE.js",
                       "raw": "'./eval-gtbndng-indirect-update-dflt_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   },
                   "property": {
                     "type": "Identifier",

--- a/test/language/expressions/dynamic-import/usage/nested-async-gen-await-eval-gtbndng-indirect-update.json
+++ b/test/language/expressions/dynamic-import/usage/nested-async-gen-await-eval-gtbndng-indirect-update.json
@@ -75,7 +75,8 @@
                       "value": "./eval-gtbndng-indirect-update_FIXTURE.js",
                       "raw": "'./eval-gtbndng-indirect-update_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   },
                   "property": {
                     "type": "Identifier",

--- a/test/language/expressions/dynamic-import/usage/nested-async-gen-await-eval-script-code-host-resolves-module-code.json
+++ b/test/language/expressions/dynamic-import/usage/nested-async-gen-await-eval-script-code-host-resolves-module-code.json
@@ -116,7 +116,8 @@
                       "value": "./module-code_FIXTURE.js",
                       "raw": "'./module-code_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   },
                   "property": {
                     "type": "Identifier",

--- a/test/language/expressions/dynamic-import/usage/nested-async-gen-await-is-call-expression-square-brackets.json
+++ b/test/language/expressions/dynamic-import/usage/nested-async-gen-await-is-call-expression-square-brackets.json
@@ -83,7 +83,8 @@
                           "value": "./dynamic-import-module_FIXTURE.js",
                           "raw": "'./dynamic-import-module_FIXTURE.js'"
                         },
-                        "options": null
+                        "options": null,
+                        "phase": null
                       },
                       "property": {
                         "type": "Literal",

--- a/test/language/expressions/dynamic-import/usage/nested-async-gen-await-returns-thenable.json
+++ b/test/language/expressions/dynamic-import/usage/nested-async-gen-await-returns-thenable.json
@@ -75,7 +75,8 @@
                       "value": "./dynamic-import-module_FIXTURE.js",
                       "raw": "'./dynamic-import-module_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   },
                   "property": {
                     "type": "Identifier",

--- a/test/language/expressions/dynamic-import/usage/nested-async-gen-await-specifier-tostring.json
+++ b/test/language/expressions/dynamic-import/usage/nested-async-gen-await-specifier-tostring.json
@@ -144,7 +144,8 @@
                       "end": 1885,
                       "name": "obj"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   },
                   "property": {
                     "type": "Identifier",

--- a/test/language/expressions/dynamic-import/usage/nested-async-gen-return-await-eval-gtbndng-indirect-update-dflt.json
+++ b/test/language/expressions/dynamic-import/usage/nested-async-gen-return-await-eval-gtbndng-indirect-update-dflt.json
@@ -41,7 +41,8 @@
                   "value": "./eval-gtbndng-indirect-update-dflt_FIXTURE.js",
                   "raw": "'./eval-gtbndng-indirect-update-dflt_FIXTURE.js'"
                 },
-                "options": null
+                "options": null,
+                "phase": null
               }
             }
           }

--- a/test/language/expressions/dynamic-import/usage/nested-async-gen-return-await-eval-gtbndng-indirect-update.json
+++ b/test/language/expressions/dynamic-import/usage/nested-async-gen-return-await-eval-gtbndng-indirect-update.json
@@ -41,7 +41,8 @@
                   "value": "./eval-gtbndng-indirect-update_FIXTURE.js",
                   "raw": "'./eval-gtbndng-indirect-update_FIXTURE.js'"
                 },
-                "options": null
+                "options": null,
+                "phase": null
               }
             }
           }

--- a/test/language/expressions/dynamic-import/usage/nested-async-gen-return-await-eval-script-code-host-resolves-module-code.json
+++ b/test/language/expressions/dynamic-import/usage/nested-async-gen-return-await-eval-script-code-host-resolves-module-code.json
@@ -82,7 +82,8 @@
                   "value": "./module-code_FIXTURE.js",
                   "raw": "'./module-code_FIXTURE.js'"
                 },
-                "options": null
+                "options": null,
+                "phase": null
               }
             }
           }

--- a/test/language/expressions/dynamic-import/usage/nested-async-gen-return-await-is-call-expression-square-brackets.json
+++ b/test/language/expressions/dynamic-import/usage/nested-async-gen-return-await-is-call-expression-square-brackets.json
@@ -49,7 +49,8 @@
                       "value": "./dynamic-import-module_FIXTURE.js",
                       "raw": "'./dynamic-import-module_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   },
                   "property": {
                     "type": "Literal",

--- a/test/language/expressions/dynamic-import/usage/nested-async-gen-return-await-returns-thenable.json
+++ b/test/language/expressions/dynamic-import/usage/nested-async-gen-return-await-returns-thenable.json
@@ -41,7 +41,8 @@
                   "value": "./dynamic-import-module_FIXTURE.js",
                   "raw": "'./dynamic-import-module_FIXTURE.js'"
                 },
-                "options": null
+                "options": null,
+                "phase": null
               }
             }
           }

--- a/test/language/expressions/dynamic-import/usage/nested-async-gen-return-await-specifier-tostring.json
+++ b/test/language/expressions/dynamic-import/usage/nested-async-gen-return-await-specifier-tostring.json
@@ -110,7 +110,8 @@
                   "end": 1887,
                   "name": "obj"
                 },
-                "options": null
+                "options": null,
+                "phase": null
               }
             }
           }

--- a/test/language/expressions/dynamic-import/usage/nested-block-import-then-eval-gtbndng-indirect-update-dflt.json
+++ b/test/language/expressions/dynamic-import/usage/nested-block-import-then-eval-gtbndng-indirect-update-dflt.json
@@ -47,7 +47,8 @@
                           "value": "./eval-gtbndng-indirect-update-dflt_FIXTURE.js",
                           "raw": "'./eval-gtbndng-indirect-update-dflt_FIXTURE.js'"
                         },
-                        "options": null
+                        "options": null,
+                        "phase": null
                       },
                       "property": {
                         "type": "Identifier",

--- a/test/language/expressions/dynamic-import/usage/nested-block-import-then-eval-gtbndng-indirect-update.json
+++ b/test/language/expressions/dynamic-import/usage/nested-block-import-then-eval-gtbndng-indirect-update.json
@@ -47,7 +47,8 @@
                           "value": "./eval-gtbndng-indirect-update_FIXTURE.js",
                           "raw": "'./eval-gtbndng-indirect-update_FIXTURE.js'"
                         },
-                        "options": null
+                        "options": null,
+                        "phase": null
                       },
                       "property": {
                         "type": "Identifier",

--- a/test/language/expressions/dynamic-import/usage/nested-block-import-then-eval-script-code-host-resolves-module-code.json
+++ b/test/language/expressions/dynamic-import/usage/nested-block-import-then-eval-script-code-host-resolves-module-code.json
@@ -88,7 +88,8 @@
                           "value": "./module-code_FIXTURE.js",
                           "raw": "'./module-code_FIXTURE.js'"
                         },
-                        "options": null
+                        "options": null,
+                        "phase": null
                       },
                       "property": {
                         "type": "Identifier",

--- a/test/language/expressions/dynamic-import/usage/nested-block-import-then-is-call-expression-square-brackets.json
+++ b/test/language/expressions/dynamic-import/usage/nested-block-import-then-is-call-expression-square-brackets.json
@@ -55,7 +55,8 @@
                               "value": "./dynamic-import-module_FIXTURE.js",
                               "raw": "'./dynamic-import-module_FIXTURE.js'"
                             },
-                            "options": null
+                            "options": null,
+                            "phase": null
                           },
                           "property": {
                             "type": "Literal",

--- a/test/language/expressions/dynamic-import/usage/nested-block-import-then-returns-thenable.json
+++ b/test/language/expressions/dynamic-import/usage/nested-block-import-then-returns-thenable.json
@@ -47,7 +47,8 @@
                           "value": "./dynamic-import-module_FIXTURE.js",
                           "raw": "'./dynamic-import-module_FIXTURE.js'"
                         },
-                        "options": null
+                        "options": null,
+                        "phase": null
                       },
                       "property": {
                         "type": "Identifier",

--- a/test/language/expressions/dynamic-import/usage/nested-block-import-then-specifier-tostring.json
+++ b/test/language/expressions/dynamic-import/usage/nested-block-import-then-specifier-tostring.json
@@ -116,7 +116,8 @@
                           "end": 1783,
                           "name": "obj"
                         },
-                        "options": null
+                        "options": null,
+                        "phase": null
                       },
                       "property": {
                         "type": "Identifier",

--- a/test/language/expressions/dynamic-import/usage/nested-do-while-eval-gtbndng-indirect-update-dflt.json
+++ b/test/language/expressions/dynamic-import/usage/nested-do-while-eval-gtbndng-indirect-update-dflt.json
@@ -51,7 +51,8 @@
                             "value": "./eval-gtbndng-indirect-update-dflt_FIXTURE.js",
                             "raw": "'./eval-gtbndng-indirect-update-dflt_FIXTURE.js'"
                           },
-                          "options": null
+                          "options": null,
+                          "phase": null
                         },
                         "property": {
                           "type": "Identifier",

--- a/test/language/expressions/dynamic-import/usage/nested-do-while-eval-gtbndng-indirect-update.json
+++ b/test/language/expressions/dynamic-import/usage/nested-do-while-eval-gtbndng-indirect-update.json
@@ -51,7 +51,8 @@
                             "value": "./eval-gtbndng-indirect-update_FIXTURE.js",
                             "raw": "'./eval-gtbndng-indirect-update_FIXTURE.js'"
                           },
-                          "options": null
+                          "options": null,
+                          "phase": null
                         },
                         "property": {
                           "type": "Identifier",

--- a/test/language/expressions/dynamic-import/usage/nested-do-while-eval-script-code-host-resolves-module-code.json
+++ b/test/language/expressions/dynamic-import/usage/nested-do-while-eval-script-code-host-resolves-module-code.json
@@ -92,7 +92,8 @@
                             "value": "./module-code_FIXTURE.js",
                             "raw": "'./module-code_FIXTURE.js'"
                           },
-                          "options": null
+                          "options": null,
+                          "phase": null
                         },
                         "property": {
                           "type": "Identifier",

--- a/test/language/expressions/dynamic-import/usage/nested-do-while-is-call-expression-square-brackets.json
+++ b/test/language/expressions/dynamic-import/usage/nested-do-while-is-call-expression-square-brackets.json
@@ -59,7 +59,8 @@
                                 "value": "./dynamic-import-module_FIXTURE.js",
                                 "raw": "'./dynamic-import-module_FIXTURE.js'"
                               },
-                              "options": null
+                              "options": null,
+                              "phase": null
                             },
                             "property": {
                               "type": "Literal",

--- a/test/language/expressions/dynamic-import/usage/nested-do-while-returns-thenable.json
+++ b/test/language/expressions/dynamic-import/usage/nested-do-while-returns-thenable.json
@@ -51,7 +51,8 @@
                             "value": "./dynamic-import-module_FIXTURE.js",
                             "raw": "'./dynamic-import-module_FIXTURE.js'"
                           },
-                          "options": null
+                          "options": null,
+                          "phase": null
                         },
                         "property": {
                           "type": "Identifier",

--- a/test/language/expressions/dynamic-import/usage/nested-do-while-specifier-tostring.json
+++ b/test/language/expressions/dynamic-import/usage/nested-do-while-specifier-tostring.json
@@ -120,7 +120,8 @@
                             "end": 1799,
                             "name": "obj"
                           },
-                          "options": null
+                          "options": null,
+                          "phase": null
                         },
                         "property": {
                           "type": "Identifier",

--- a/test/language/expressions/dynamic-import/usage/nested-else-import-then-eval-gtbndng-indirect-update-dflt.json
+++ b/test/language/expressions/dynamic-import/usage/nested-else-import-then-eval-gtbndng-indirect-update-dflt.json
@@ -64,7 +64,8 @@
                             "value": "./eval-gtbndng-indirect-update-dflt_FIXTURE.js",
                             "raw": "'./eval-gtbndng-indirect-update-dflt_FIXTURE.js'"
                           },
-                          "options": null
+                          "options": null,
+                          "phase": null
                         },
                         "property": {
                           "type": "Identifier",

--- a/test/language/expressions/dynamic-import/usage/nested-else-import-then-eval-gtbndng-indirect-update.json
+++ b/test/language/expressions/dynamic-import/usage/nested-else-import-then-eval-gtbndng-indirect-update.json
@@ -64,7 +64,8 @@
                             "value": "./eval-gtbndng-indirect-update_FIXTURE.js",
                             "raw": "'./eval-gtbndng-indirect-update_FIXTURE.js'"
                           },
-                          "options": null
+                          "options": null,
+                          "phase": null
                         },
                         "property": {
                           "type": "Identifier",

--- a/test/language/expressions/dynamic-import/usage/nested-else-import-then-eval-script-code-host-resolves-module-code.json
+++ b/test/language/expressions/dynamic-import/usage/nested-else-import-then-eval-script-code-host-resolves-module-code.json
@@ -105,7 +105,8 @@
                             "value": "./module-code_FIXTURE.js",
                             "raw": "'./module-code_FIXTURE.js'"
                           },
-                          "options": null
+                          "options": null,
+                          "phase": null
                         },
                         "property": {
                           "type": "Identifier",

--- a/test/language/expressions/dynamic-import/usage/nested-else-import-then-is-call-expression-square-brackets.json
+++ b/test/language/expressions/dynamic-import/usage/nested-else-import-then-is-call-expression-square-brackets.json
@@ -72,7 +72,8 @@
                                 "value": "./dynamic-import-module_FIXTURE.js",
                                 "raw": "'./dynamic-import-module_FIXTURE.js'"
                               },
-                              "options": null
+                              "options": null,
+                              "phase": null
                             },
                             "property": {
                               "type": "Literal",

--- a/test/language/expressions/dynamic-import/usage/nested-else-import-then-returns-thenable.json
+++ b/test/language/expressions/dynamic-import/usage/nested-else-import-then-returns-thenable.json
@@ -64,7 +64,8 @@
                             "value": "./dynamic-import-module_FIXTURE.js",
                             "raw": "'./dynamic-import-module_FIXTURE.js'"
                           },
-                          "options": null
+                          "options": null,
+                          "phase": null
                         },
                         "property": {
                           "type": "Identifier",

--- a/test/language/expressions/dynamic-import/usage/nested-else-import-then-specifier-tostring.json
+++ b/test/language/expressions/dynamic-import/usage/nested-else-import-then-specifier-tostring.json
@@ -133,7 +133,8 @@
                             "end": 1802,
                             "name": "obj"
                           },
-                          "options": null
+                          "options": null,
+                          "phase": null
                         },
                         "property": {
                           "type": "Identifier",

--- a/test/language/expressions/dynamic-import/usage/nested-function-import-then-eval-gtbndng-indirect-update-dflt.json
+++ b/test/language/expressions/dynamic-import/usage/nested-function-import-then-eval-gtbndng-indirect-update-dflt.json
@@ -61,7 +61,8 @@
                             "value": "./eval-gtbndng-indirect-update-dflt_FIXTURE.js",
                             "raw": "'./eval-gtbndng-indirect-update-dflt_FIXTURE.js'"
                           },
-                          "options": null
+                          "options": null,
+                          "phase": null
                         },
                         "property": {
                           "type": "Identifier",

--- a/test/language/expressions/dynamic-import/usage/nested-function-import-then-eval-gtbndng-indirect-update.json
+++ b/test/language/expressions/dynamic-import/usage/nested-function-import-then-eval-gtbndng-indirect-update.json
@@ -61,7 +61,8 @@
                             "value": "./eval-gtbndng-indirect-update_FIXTURE.js",
                             "raw": "'./eval-gtbndng-indirect-update_FIXTURE.js'"
                           },
-                          "options": null
+                          "options": null,
+                          "phase": null
                         },
                         "property": {
                           "type": "Identifier",

--- a/test/language/expressions/dynamic-import/usage/nested-function-import-then-eval-script-code-host-resolves-module-code.json
+++ b/test/language/expressions/dynamic-import/usage/nested-function-import-then-eval-script-code-host-resolves-module-code.json
@@ -102,7 +102,8 @@
                             "value": "./module-code_FIXTURE.js",
                             "raw": "'./module-code_FIXTURE.js'"
                           },
-                          "options": null
+                          "options": null,
+                          "phase": null
                         },
                         "property": {
                           "type": "Identifier",

--- a/test/language/expressions/dynamic-import/usage/nested-function-import-then-is-call-expression-square-brackets.json
+++ b/test/language/expressions/dynamic-import/usage/nested-function-import-then-is-call-expression-square-brackets.json
@@ -69,7 +69,8 @@
                                 "value": "./dynamic-import-module_FIXTURE.js",
                                 "raw": "'./dynamic-import-module_FIXTURE.js'"
                               },
-                              "options": null
+                              "options": null,
+                              "phase": null
                             },
                             "property": {
                               "type": "Literal",

--- a/test/language/expressions/dynamic-import/usage/nested-function-import-then-returns-thenable.json
+++ b/test/language/expressions/dynamic-import/usage/nested-function-import-then-returns-thenable.json
@@ -61,7 +61,8 @@
                             "value": "./dynamic-import-module_FIXTURE.js",
                             "raw": "'./dynamic-import-module_FIXTURE.js'"
                           },
-                          "options": null
+                          "options": null,
+                          "phase": null
                         },
                         "property": {
                           "type": "Identifier",

--- a/test/language/expressions/dynamic-import/usage/nested-function-import-then-specifier-tostring.json
+++ b/test/language/expressions/dynamic-import/usage/nested-function-import-then-specifier-tostring.json
@@ -130,7 +130,8 @@
                             "end": 1802,
                             "name": "obj"
                           },
-                          "options": null
+                          "options": null,
+                          "phase": null
                         },
                         "property": {
                           "type": "Identifier",

--- a/test/language/expressions/dynamic-import/usage/nested-if-braceless-eval-gtbndng-indirect-update-dflt.json
+++ b/test/language/expressions/dynamic-import/usage/nested-if-braceless-eval-gtbndng-indirect-update-dflt.json
@@ -53,7 +53,8 @@
                         "value": "./eval-gtbndng-indirect-update-dflt_FIXTURE.js",
                         "raw": "'./eval-gtbndng-indirect-update-dflt_FIXTURE.js'"
                       },
-                      "options": null
+                      "options": null,
+                      "phase": null
                     },
                     "property": {
                       "type": "Identifier",

--- a/test/language/expressions/dynamic-import/usage/nested-if-braceless-eval-gtbndng-indirect-update.json
+++ b/test/language/expressions/dynamic-import/usage/nested-if-braceless-eval-gtbndng-indirect-update.json
@@ -53,7 +53,8 @@
                         "value": "./eval-gtbndng-indirect-update_FIXTURE.js",
                         "raw": "'./eval-gtbndng-indirect-update_FIXTURE.js'"
                       },
-                      "options": null
+                      "options": null,
+                      "phase": null
                     },
                     "property": {
                       "type": "Identifier",

--- a/test/language/expressions/dynamic-import/usage/nested-if-braceless-eval-script-code-host-resolves-module-code.json
+++ b/test/language/expressions/dynamic-import/usage/nested-if-braceless-eval-script-code-host-resolves-module-code.json
@@ -94,7 +94,8 @@
                         "value": "./module-code_FIXTURE.js",
                         "raw": "'./module-code_FIXTURE.js'"
                       },
-                      "options": null
+                      "options": null,
+                      "phase": null
                     },
                     "property": {
                       "type": "Identifier",

--- a/test/language/expressions/dynamic-import/usage/nested-if-braceless-is-call-expression-square-brackets.json
+++ b/test/language/expressions/dynamic-import/usage/nested-if-braceless-is-call-expression-square-brackets.json
@@ -61,7 +61,8 @@
                             "value": "./dynamic-import-module_FIXTURE.js",
                             "raw": "'./dynamic-import-module_FIXTURE.js'"
                           },
-                          "options": null
+                          "options": null,
+                          "phase": null
                         },
                         "property": {
                           "type": "Literal",

--- a/test/language/expressions/dynamic-import/usage/nested-if-braceless-returns-thenable.json
+++ b/test/language/expressions/dynamic-import/usage/nested-if-braceless-returns-thenable.json
@@ -53,7 +53,8 @@
                         "value": "./dynamic-import-module_FIXTURE.js",
                         "raw": "'./dynamic-import-module_FIXTURE.js'"
                       },
-                      "options": null
+                      "options": null,
+                      "phase": null
                     },
                     "property": {
                       "type": "Identifier",

--- a/test/language/expressions/dynamic-import/usage/nested-if-braceless-specifier-tostring.json
+++ b/test/language/expressions/dynamic-import/usage/nested-if-braceless-specifier-tostring.json
@@ -122,7 +122,8 @@
                         "end": 1800,
                         "name": "obj"
                       },
-                      "options": null
+                      "options": null,
+                      "phase": null
                     },
                     "property": {
                       "type": "Identifier",

--- a/test/language/expressions/dynamic-import/usage/nested-if-import-then-eval-gtbndng-indirect-update-dflt.json
+++ b/test/language/expressions/dynamic-import/usage/nested-if-import-then-eval-gtbndng-indirect-update-dflt.json
@@ -58,7 +58,8 @@
                             "value": "./eval-gtbndng-indirect-update-dflt_FIXTURE.js",
                             "raw": "'./eval-gtbndng-indirect-update-dflt_FIXTURE.js'"
                           },
-                          "options": null
+                          "options": null,
+                          "phase": null
                         },
                         "property": {
                           "type": "Identifier",

--- a/test/language/expressions/dynamic-import/usage/nested-if-import-then-eval-gtbndng-indirect-update.json
+++ b/test/language/expressions/dynamic-import/usage/nested-if-import-then-eval-gtbndng-indirect-update.json
@@ -58,7 +58,8 @@
                             "value": "./eval-gtbndng-indirect-update_FIXTURE.js",
                             "raw": "'./eval-gtbndng-indirect-update_FIXTURE.js'"
                           },
-                          "options": null
+                          "options": null,
+                          "phase": null
                         },
                         "property": {
                           "type": "Identifier",

--- a/test/language/expressions/dynamic-import/usage/nested-if-import-then-eval-script-code-host-resolves-module-code.json
+++ b/test/language/expressions/dynamic-import/usage/nested-if-import-then-eval-script-code-host-resolves-module-code.json
@@ -99,7 +99,8 @@
                             "value": "./module-code_FIXTURE.js",
                             "raw": "'./module-code_FIXTURE.js'"
                           },
-                          "options": null
+                          "options": null,
+                          "phase": null
                         },
                         "property": {
                           "type": "Identifier",

--- a/test/language/expressions/dynamic-import/usage/nested-if-import-then-is-call-expression-square-brackets.json
+++ b/test/language/expressions/dynamic-import/usage/nested-if-import-then-is-call-expression-square-brackets.json
@@ -66,7 +66,8 @@
                                 "value": "./dynamic-import-module_FIXTURE.js",
                                 "raw": "'./dynamic-import-module_FIXTURE.js'"
                               },
-                              "options": null
+                              "options": null,
+                              "phase": null
                             },
                             "property": {
                               "type": "Literal",

--- a/test/language/expressions/dynamic-import/usage/nested-if-import-then-returns-thenable.json
+++ b/test/language/expressions/dynamic-import/usage/nested-if-import-then-returns-thenable.json
@@ -58,7 +58,8 @@
                             "value": "./dynamic-import-module_FIXTURE.js",
                             "raw": "'./dynamic-import-module_FIXTURE.js'"
                           },
-                          "options": null
+                          "options": null,
+                          "phase": null
                         },
                         "property": {
                           "type": "Identifier",

--- a/test/language/expressions/dynamic-import/usage/nested-if-import-then-specifier-tostring.json
+++ b/test/language/expressions/dynamic-import/usage/nested-if-import-then-specifier-tostring.json
@@ -127,7 +127,8 @@
                             "end": 1787,
                             "name": "obj"
                           },
-                          "options": null
+                          "options": null,
+                          "phase": null
                         },
                         "property": {
                           "type": "Identifier",

--- a/test/language/expressions/dynamic-import/usage/nested-while-import-then-eval-gtbndng-indirect-update-dflt.json
+++ b/test/language/expressions/dynamic-import/usage/nested-while-import-then-eval-gtbndng-indirect-update-dflt.json
@@ -108,7 +108,8 @@
                             "value": "./eval-gtbndng-indirect-update-dflt_FIXTURE.js",
                             "raw": "'./eval-gtbndng-indirect-update-dflt_FIXTURE.js'"
                           },
-                          "options": null
+                          "options": null,
+                          "phase": null
                         },
                         "property": {
                           "type": "Identifier",

--- a/test/language/expressions/dynamic-import/usage/nested-while-import-then-eval-gtbndng-indirect-update.json
+++ b/test/language/expressions/dynamic-import/usage/nested-while-import-then-eval-gtbndng-indirect-update.json
@@ -108,7 +108,8 @@
                             "value": "./eval-gtbndng-indirect-update_FIXTURE.js",
                             "raw": "'./eval-gtbndng-indirect-update_FIXTURE.js'"
                           },
-                          "options": null
+                          "options": null,
+                          "phase": null
                         },
                         "property": {
                           "type": "Identifier",

--- a/test/language/expressions/dynamic-import/usage/nested-while-import-then-eval-script-code-host-resolves-module-code.json
+++ b/test/language/expressions/dynamic-import/usage/nested-while-import-then-eval-script-code-host-resolves-module-code.json
@@ -149,7 +149,8 @@
                             "value": "./module-code_FIXTURE.js",
                             "raw": "'./module-code_FIXTURE.js'"
                           },
-                          "options": null
+                          "options": null,
+                          "phase": null
                         },
                         "property": {
                           "type": "Identifier",

--- a/test/language/expressions/dynamic-import/usage/nested-while-import-then-is-call-expression-square-brackets.json
+++ b/test/language/expressions/dynamic-import/usage/nested-while-import-then-is-call-expression-square-brackets.json
@@ -116,7 +116,8 @@
                                 "value": "./dynamic-import-module_FIXTURE.js",
                                 "raw": "'./dynamic-import-module_FIXTURE.js'"
                               },
-                              "options": null
+                              "options": null,
+                              "phase": null
                             },
                             "property": {
                               "type": "Literal",

--- a/test/language/expressions/dynamic-import/usage/nested-while-import-then-returns-thenable.json
+++ b/test/language/expressions/dynamic-import/usage/nested-while-import-then-returns-thenable.json
@@ -108,7 +108,8 @@
                             "value": "./dynamic-import-module_FIXTURE.js",
                             "raw": "'./dynamic-import-module_FIXTURE.js'"
                           },
-                          "options": null
+                          "options": null,
+                          "phase": null
                         },
                         "property": {
                           "type": "Identifier",

--- a/test/language/expressions/dynamic-import/usage/nested-while-import-then-specifier-tostring.json
+++ b/test/language/expressions/dynamic-import/usage/nested-while-import-then-specifier-tostring.json
@@ -177,7 +177,8 @@
                             "end": 1812,
                             "name": "obj"
                           },
-                          "options": null
+                          "options": null,
+                          "phase": null
                         },
                         "property": {
                           "type": "Identifier",

--- a/test/language/expressions/dynamic-import/usage/syntax-nested-block-labeled-eval-gtbndng-indirect-update-dflt.json
+++ b/test/language/expressions/dynamic-import/usage/syntax-nested-block-labeled-eval-gtbndng-indirect-update-dflt.json
@@ -51,7 +51,8 @@
                             "value": "./eval-gtbndng-indirect-update-dflt_FIXTURE.js",
                             "raw": "'./eval-gtbndng-indirect-update-dflt_FIXTURE.js'"
                           },
-                          "options": null
+                          "options": null,
+                          "phase": null
                         },
                         "property": {
                           "type": "Identifier",

--- a/test/language/expressions/dynamic-import/usage/syntax-nested-block-labeled-eval-gtbndng-indirect-update.json
+++ b/test/language/expressions/dynamic-import/usage/syntax-nested-block-labeled-eval-gtbndng-indirect-update.json
@@ -51,7 +51,8 @@
                             "value": "./eval-gtbndng-indirect-update_FIXTURE.js",
                             "raw": "'./eval-gtbndng-indirect-update_FIXTURE.js'"
                           },
-                          "options": null
+                          "options": null,
+                          "phase": null
                         },
                         "property": {
                           "type": "Identifier",

--- a/test/language/expressions/dynamic-import/usage/syntax-nested-block-labeled-eval-script-code-host-resolves-module-code.json
+++ b/test/language/expressions/dynamic-import/usage/syntax-nested-block-labeled-eval-script-code-host-resolves-module-code.json
@@ -92,7 +92,8 @@
                             "value": "./module-code_FIXTURE.js",
                             "raw": "'./module-code_FIXTURE.js'"
                           },
-                          "options": null
+                          "options": null,
+                          "phase": null
                         },
                         "property": {
                           "type": "Identifier",

--- a/test/language/expressions/dynamic-import/usage/syntax-nested-block-labeled-is-call-expression-square-brackets.json
+++ b/test/language/expressions/dynamic-import/usage/syntax-nested-block-labeled-is-call-expression-square-brackets.json
@@ -59,7 +59,8 @@
                                 "value": "./dynamic-import-module_FIXTURE.js",
                                 "raw": "'./dynamic-import-module_FIXTURE.js'"
                               },
-                              "options": null
+                              "options": null,
+                              "phase": null
                             },
                             "property": {
                               "type": "Literal",

--- a/test/language/expressions/dynamic-import/usage/syntax-nested-block-labeled-returns-thenable.json
+++ b/test/language/expressions/dynamic-import/usage/syntax-nested-block-labeled-returns-thenable.json
@@ -51,7 +51,8 @@
                             "value": "./dynamic-import-module_FIXTURE.js",
                             "raw": "'./dynamic-import-module_FIXTURE.js'"
                           },
-                          "options": null
+                          "options": null,
+                          "phase": null
                         },
                         "property": {
                           "type": "Identifier",

--- a/test/language/expressions/dynamic-import/usage/syntax-nested-block-labeled-specifier-tostring.json
+++ b/test/language/expressions/dynamic-import/usage/syntax-nested-block-labeled-specifier-tostring.json
@@ -120,7 +120,8 @@
                             "end": 1805,
                             "name": "obj"
                           },
-                          "options": null
+                          "options": null,
+                          "phase": null
                         },
                         "property": {
                           "type": "Identifier",

--- a/test/language/expressions/dynamic-import/usage/top-level-import-then-eval-gtbndng-indirect-update-dflt.json
+++ b/test/language/expressions/dynamic-import/usage/top-level-import-then-eval-gtbndng-indirect-update-dflt.json
@@ -42,7 +42,8 @@
                       "value": "./eval-gtbndng-indirect-update-dflt_FIXTURE.js",
                       "raw": "'./eval-gtbndng-indirect-update-dflt_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   },
                   "property": {
                     "type": "Identifier",

--- a/test/language/expressions/dynamic-import/usage/top-level-import-then-eval-gtbndng-indirect-update.json
+++ b/test/language/expressions/dynamic-import/usage/top-level-import-then-eval-gtbndng-indirect-update.json
@@ -42,7 +42,8 @@
                       "value": "./eval-gtbndng-indirect-update_FIXTURE.js",
                       "raw": "'./eval-gtbndng-indirect-update_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   },
                   "property": {
                     "type": "Identifier",

--- a/test/language/expressions/dynamic-import/usage/top-level-import-then-eval-script-code-host-resolves-module-code.json
+++ b/test/language/expressions/dynamic-import/usage/top-level-import-then-eval-script-code-host-resolves-module-code.json
@@ -83,7 +83,8 @@
                       "value": "./module-code_FIXTURE.js",
                       "raw": "'./module-code_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   },
                   "property": {
                     "type": "Identifier",

--- a/test/language/expressions/dynamic-import/usage/top-level-import-then-is-call-expression-square-brackets.json
+++ b/test/language/expressions/dynamic-import/usage/top-level-import-then-is-call-expression-square-brackets.json
@@ -50,7 +50,8 @@
                           "value": "./dynamic-import-module_FIXTURE.js",
                           "raw": "'./dynamic-import-module_FIXTURE.js'"
                         },
-                        "options": null
+                        "options": null,
+                        "phase": null
                       },
                       "property": {
                         "type": "Literal",

--- a/test/language/expressions/dynamic-import/usage/top-level-import-then-returns-thenable.json
+++ b/test/language/expressions/dynamic-import/usage/top-level-import-then-returns-thenable.json
@@ -42,7 +42,8 @@
                       "value": "./dynamic-import-module_FIXTURE.js",
                       "raw": "'./dynamic-import-module_FIXTURE.js'"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   },
                   "property": {
                     "type": "Identifier",

--- a/test/language/expressions/dynamic-import/usage/top-level-import-then-specifier-tostring.json
+++ b/test/language/expressions/dynamic-import/usage/top-level-import-then-specifier-tostring.json
@@ -111,7 +111,8 @@
                       "end": 1773,
                       "name": "obj"
                     },
-                    "options": null
+                    "options": null,
+                    "phase": null
                   },
                   "property": {
                     "type": "Identifier",

--- a/test/language/import/import-attributes/json-idempotency.json
+++ b/test/language/import/import-attributes/json-idempotency.json
@@ -298,7 +298,8 @@
                       "kind": "init"
                     }
                   ]
-                }
+                },
+                "phase": null
               },
               "property": {
                 "type": "Identifier",

--- a/test/language/import/import-defer/errors/module-throws/defer-import-after-evaluation.json
+++ b/test/language/import/import-defer/errors/module-throws/defer-import-after-evaluation.json
@@ -79,7 +79,8 @@
                             "value": "./throws_FIXTURE.js",
                             "raw": "\"./throws_FIXTURE.js\""
                           },
-                          "options": null
+                          "options": null,
+                          "phase": null
                         },
                         "property": {
                           "type": "Identifier",
@@ -253,7 +254,8 @@
                             "value": "./import-defer-throws_FIXTURE.js",
                             "raw": "\"./import-defer-throws_FIXTURE.js\""
                           },
-                          "options": null
+                          "options": null,
+                          "phase": null
                         }
                       }
                     }

--- a/test/language/module-code/top-level-await/await-dynamic-import-rejection.json
+++ b/test/language/module-code/top-level-await/await-dynamic-import-rejection.json
@@ -22,7 +22,8 @@
             "value": "./module-import-rejection-body_FIXTURE.js",
             "raw": "'./module-import-rejection-body_FIXTURE.js'"
           },
-          "options": null
+          "options": null,
+          "phase": null
         }
       }
     },

--- a/test/language/module-code/top-level-await/await-dynamic-import-resolution.json
+++ b/test/language/module-code/top-level-await/await-dynamic-import-resolution.json
@@ -33,7 +33,8 @@
                 "value": "./module-import-resolution_FIXTURE.js",
                 "raw": "'./module-import-resolution_FIXTURE.js'"
               },
-              "options": null
+              "options": null,
+              "phase": null
             }
           }
         }

--- a/test/language/module-code/top-level-await/dynamic-import-rejection.json
+++ b/test/language/module-code/top-level-await/dynamic-import-rejection.json
@@ -34,7 +34,8 @@
                   "value": "./module-import-rejection_FIXTURE.js",
                   "raw": "'./module-import-rejection_FIXTURE.js'"
                 },
-                "options": null
+                "options": null,
+                "phase": null
               },
               "property": {
                 "type": "Identifier",

--- a/test/language/module-code/top-level-await/dynamic-import-resolution.json
+++ b/test/language/module-code/top-level-await/dynamic-import-resolution.json
@@ -34,7 +34,8 @@
                   "value": "./module-import-resolution_FIXTURE.js",
                   "raw": "'./module-import-resolution_FIXTURE.js'"
                 },
-                "options": null
+                "options": null,
+                "phase": null
               },
               "property": {
                 "type": "Identifier",

--- a/test/language/module-code/top-level-await/module-graphs-does-not-hang.json
+++ b/test/language/module-code/top-level-await/module-graphs-does-not-hang.json
@@ -37,7 +37,8 @@
             "value": "./module-graphs-grandparent-tla_FIXTURE.js",
             "raw": "\"./module-graphs-grandparent-tla_FIXTURE.js\""
           },
-          "options": null
+          "options": null,
+          "phase": null
         }
       }
     },

--- a/test/language/module-code/top-level-await/syntax/await-expr-dyn-import.json
+++ b/test/language/module-code/top-level-await/syntax/await-expr-dyn-import.json
@@ -31,7 +31,8 @@
                   "value": "foo",
                   "raw": "'foo'"
                 },
-                "options": null
+                "options": null,
+                "phase": null
               }
             }
           }

--- a/utils/json.js
+++ b/utils/json.js
@@ -7,14 +7,14 @@ const INFINITY_REGEXP = new RegExp(`"${INFINITY_PLACEHOLDER}"`, 'g');
 // * Replace `Infinity` with `"__INFINITY__INFINITY__INFINITY__"` placeholder
 //   which will be replaced in JSON with `1e+400`.
 // * Sort RegExp `Literal`s' `regex.flags` property in alphabetical order, the way V8 does.
-// * Add `phase` field to `ImportDeclaration`.
+// * Add `phase` field to `ImportDeclaration` and `ImportExpression`.
 function transformerAcorn(_key, value) {
   if (typeof value === 'bigint') return null;
   if (value === Infinity) return INFINITY_PLACEHOLDER;
 
   if (typeof value !== 'object' || value === null || !Object.hasOwn(value, 'type')) return value;
 
-  if (value.type === 'ImportDeclaration') {
+  if (value.type === 'ImportDeclaration' || value.type === 'ImportExpression') {
     value.phase = null;
   } else if (value.type === 'Literal' && Object.hasOwn(value, 'regex')) {
     value.regex.flags = [...value.regex.flags].sort().join('');
@@ -26,7 +26,9 @@ function transformerAcorn(_key, value) {
 
 // Transformer for TS-ESLint AST.
 //
-// Makes the same changes as `acornTransformer`, and also converts location fields.
+// Makes the same changes as `acornTransformer`, but:
+// * Also converts location fields.
+// * Does not add `phase` field to `ImportExpression`.
 function transformerTs(_key, value) {
   if (typeof value === 'bigint') return null;
   if (value === Infinity) return INFINITY_PLACEHOLDER;


### PR DESCRIPTION
Add a field `phase` to `ImportExpresion` in JS AST only, to support https://github.com/oxc-project/oxc/issues/10978.

This field is always `null` because Acorn does not support this syntax.