### PR TITLE
refactor: bump `meriyah` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@typescript-eslint/parser": "^8.34.1",
     "acorn": "8.15.0",
     "estree-walker": "^3.0.3",
-    "meriyah": "^6.1.2",
+    "meriyah": "^6.1.4",
     "yaml": "^2.7.0"
   },
   "packageManager": "pnpm@10.10.0+sha512.d615db246fe70f25dcfea6d8d73dee782ce23e2245e3c4f6f888249fb568149318637dca73c2c5c8ef2a4ca0d5657fb9567188bfab47f566d1ee6ce987815c39"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: ^3.0.3
         version: 3.0.3
       meriyah:
-        specifier: ^6.1.2
-        version: 6.1.2
+        specifier: ^6.1.4
+        version: 6.1.4
       yaml:
         specifier: ^2.7.0
         version: 2.7.1
@@ -292,10 +292,6 @@ packages:
     resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
-  eslint-visitor-keys@4.2.0:
-    resolution: {integrity: sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
   eslint-visitor-keys@4.2.1:
     resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -529,8 +525,8 @@ packages:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
 
-  meriyah@6.1.2:
-    resolution: {integrity: sha512-yZmgi3bsRdaoFlKoz9PkNhTSmfGFKNg0X6ivtEFDwL06tZHE6aG6Yfr3mnZDfVG0aYPd4Yml1fL7viHjWKnD7A==}
+  meriyah@6.1.4:
+    resolution: {integrity: sha512-Sz8FzjzI0kN13GK/6MVEsVzMZEPvOhnmmI1lU5+/1cGOiK3QUahntrNNtdVeihrO7t9JpoH75iMNXg6R6uWflQ==}
     engines: {node: '>=18.0.0'}
 
   micromatch@4.0.8:
@@ -1065,8 +1061,6 @@ snapshots:
 
   eslint-visitor-keys@3.4.3: {}
 
-  eslint-visitor-keys@4.2.0: {}
-
   eslint-visitor-keys@4.2.1: {}
 
   eslint@9.26.0:
@@ -1091,7 +1085,7 @@ snapshots:
       debug: 4.4.0
       escape-string-regexp: 4.0.0
       eslint-scope: 8.3.0
-      eslint-visitor-keys: 4.2.0
+      eslint-visitor-keys: 4.2.1
       espree: 10.3.0
       esquery: 1.6.0
       esutils: 2.0.3
@@ -1115,7 +1109,7 @@ snapshots:
     dependencies:
       acorn: 8.15.0
       acorn-jsx: 5.3.2(acorn@8.15.0)
-      eslint-visitor-keys: 4.2.0
+      eslint-visitor-keys: 4.2.1
 
   esquery@1.6.0:
     dependencies:
@@ -1340,7 +1334,7 @@ snapshots:
 
   merge2@1.4.1: {}
 
-  meriyah@6.1.2: {}
+  meriyah@6.1.4: {}
 
   micromatch@4.0.8:
     dependencies:

--- a/src/test262.js
+++ b/src/test262.js
@@ -101,24 +101,15 @@ function fixMeriyahNode(node) {
   } else if (type === 'ArrowFunctionExpression') {
     // `id` field is not in ESTree spec. Not sure why Acorn includes it.
     if (!Object.hasOwn(node, 'id')) node.id = null;
-  } else if (type === 'PropertyDefinition') {
-    // Property's span should encompass decorators.
-    // What is correct has been a matter of some debate on Babel and TS-ESLint. This matches TS-ESLint.
-    // https://github.com/meriyah/meriyah/issues/416
-    if (node.decorators && node.decorators.length > 0) node.start = node.decorators[0].start;
-  } else if (type === 'MethodDefinition') {
-    // Method's span should encompass decorators.
-    // What is correct has been a matter of some debate on Babel and TS-ESLint. This matches TS-ESLint.
-    // https://github.com/meriyah/meriyah/issues/417
-    if (node.decorators && node.decorators.length > 0) node.start = node.decorators[0].start;
   } else if (type === 'Decorator') {
-    // Wrong `start` for `CallExpression` as decorator.
-    // e.g. `@dec() class C {}` - `CallExpression`'s start should be 1 not 0.
+    // Wrong `start` for `CallExpression` or `MemberExpression` as decorator.
+    // e.g. `@dec() class C {}` - `CallExpression`'s start should be 1 not 4.
+    // e.g. `@x.y class C {}` - `MemberExpression`'s start should be 1 not 2.
     // https://github.com/meriyah/meriyah/issues/420
-    if (node.expression.type === 'CallExpression') node.expression.start = node.expression.callee.start;
-    // Wrong `start` for `MemberExpression` as decorator.
-    // e.g. `@x.y() class C {}` - `MemberExpression`'s start should be 1 not 0.
-    // https://github.com/meriyah/meriyah/issues/420
-    if (node.expression.type === 'MemberExpression') node.expression.start = node.expression.object.start;
+    if (node.expression.type === 'CallExpression') {
+      node.expression.start = node.expression.callee.start;
+    } else if (node.expression.type === 'MemberExpression') {
+      node.expression.start = node.expression.object.start;
+    }
   }
 }


### PR DESCRIPTION
Meriyah has fixed 2 bugs I reported related to ranges of `PropertyDefinition`s and `MethodDefinition`s with decorators. Bump `meriyah` dependency to latest, and remove the code we had to work around these bugs (Meriyah still has some further bugs related to decorators).
